### PR TITLE
add support for getting execution step log. fixes #16

### DIFF
--- a/src/commands/cloudmanager/get-execution-step-log.js
+++ b/src/commands/cloudmanager/get-execution-step-log.js
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Command, flags } = require('@oclif/command')
+const fs = require("fs")
+const { cli } = require('cli-ux')
+const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
+const { getApiKey, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const Client = require('../../client')
+const commonFlags = require('../../common-flags')
+
+async function _getExecutionStepLog (programId, pipelineId, executionId, action, outputStream, passphrase) {
+  const apiKey = await getApiKey()
+  const accessToken = await getAccessToken(passphrase)
+  const orgId = await getOrgId()
+  return new Client(orgId, accessToken, apiKey).getExecutionStepLog(programId, pipelineId, executionId, action, outputStream)
+}
+
+class GetExecutionStepLogs extends Command {
+  async run () {
+    const { args, flags } = this.parse(GetExecutionStepLogs)
+
+    const programId = await getProgramId(flags)
+
+    const outputStream = flags.output ? fs.createWriteStream(flags.output) : process.stdout
+
+    if (flags.output) {
+        cli.action.start(`download ${args.action} log to ${flags.output}`)
+    }
+
+    let result;
+
+    try {
+      result = await this.getExecutionStepLog(programId, args.pipelineId, args.executionId, args.action, outputStream, flags.passphrase)
+    } catch (error) {
+      this.error(error.message)
+    }
+
+    if (flags.output) {
+        cli.action.stop('downloaded')
+    }
+
+    return result
+  }
+
+  async getExecutionStepLog (programId, pipelineId, executionId, action, outputStream, passphrase = null) {
+    return _getExecutionStepLog(programId, pipelineId, executionId, action, outputStream, passphrase)
+  }
+}
+
+GetExecutionStepLogs.description = 'get step log'
+
+GetExecutionStepLogs.flags = {
+  ...commonFlags.global,
+  ...commonFlags.programId,
+  output: flags.string({ char: 'o', description: "the output file. If not set, uses standard output."})
+}
+
+GetExecutionStepLogs.args = [
+    {name: 'pipelineId', required: true, description: "the pipeline id"},
+    {name: 'executionId', required: true, description: "the execution id"},
+    {name: 'action', required: true, description: "the step action", options: [
+        'build',
+        'codeQuality',
+        'devDeploy',
+        'stageDeploy',
+        'prodDeploy'
+    ]},
+]
+
+
+module.exports = GetExecutionStepLogs

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,8 @@ module.exports = {
         cancel: 'http://ns.adobe.com/adobecloud/rel/pipeline/cancel',
         advance: 'http://ns.adobe.com/adobecloud/rel/pipeline/advance',
         executionId: 'http://ns.adobe.com/adobecloud/rel/execution/id',
-        environments: 'http://ns.adobe.com/adobecloud/rel/environments'
+        environments: 'http://ns.adobe.com/adobecloud/rel/environments',
+        logs: 'http://ns.adobe.com/adobecloud/rel/pipeline/logs'
     },
     config: {
         programId: 'cloudmanager_programid'

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ const CancelCurrentExecution = require('./commands/cloudmanager/cancel-current-e
 const AdvanceCurrentExecution = require('./commands/cloudmanager/advance-current-execution')
 const ListEnvironments = require('./commands/cloudmanager/list-environments')
 const GetExecutionStepDetails = require('./commands/cloudmanager/get-execution-step-details')
+const GetExecutionStepLog = require('./commands/cloudmanager/get-execution-step-log')
 
 module.exports = {
   'aaa': CloudManagerCommand, // needs to be first alphabetically
@@ -33,5 +34,6 @@ module.exports = {
   'cancel-current-execution': new CancelCurrentExecution().cancelCurrentExecution,
   'advance-current-execution': new AdvanceCurrentExecution().advanceCurrentExecution,
   'list-environments': new ListEnvironments().listEnvironments,
-  'get-execution-step-details': new GetExecutionStepDetails().getExecution
+  'get-execution-step-details': new GetExecutionStepDetails().getExecution,
+  'get-execution-step-log': new GetExecutionStepLog().getExecutionStepLog
 }

--- a/test/__mocks__/data/execution1001.json
+++ b/test/__mocks__/data/execution1001.json
@@ -21,7 +21,13 @@
                 "startedAt": "2019-05-23T13:49:57.645+0000",
                 "finishedAt": "2019-05-23T13:55:44.904+0000",
                 "updatedAt": "2019-05-23T13:55:44.958+0000",
-                "status": "FINISHED"
+                "status": "FINISHED",
+                "_links": {
+                    "http://ns.adobe.com/adobecloud/rel/pipeline/logs": {
+                        "href": "/api/program/5/pipeline/7/execution/1001/phase/4596/step/8492/logs",
+                        "templated": false
+                    }
+                }
             },
             {
                 "id": "36516",
@@ -41,6 +47,10 @@
                 "_links": {
                     "http://ns.adobe.com/adobecloud/rel/pipeline/metrics": {
                         "href": "/api/program/5/pipeline/7/execution/1001/phase/4596/step/8493/metrics",
+                        "templated": false
+                    },
+                    "http://ns.adobe.com/adobecloud/rel/pipeline/logs": {
+                        "href": "/api/program/5/pipeline/7/execution/1001/phase/4596/step/8493/logs",
                         "templated": false
                     }
                 }
@@ -70,7 +80,13 @@
                     ],
                     "deploymentStepDescription": "[{\"id\":1,\"stepAction\":\"perform-backup\",\"instanceId\":\"author1uswest2\",\"updated\":\"2019-05-23T13:58:26.305+0000\"},{\"id\":2,\"stepAction\":\"perform-backup\",\"instanceId\":\"publish1uswest2\",\"updated\":\"2019-05-23T13:58:26.443+0000\"},{\"id\":3,\"stepAction\":\"perform-backup\",\"instanceId\":\"dispatcher1uswest2\",\"updated\":\"2019-05-23T13:58:26.484+0000\"},{\"id\":4,\"stepAction\":\"manage-elb-links-detach\",\"instanceId\":\"dispatcher1uswest2\",\"updated\":\"2019-05-23T14:05:23.819+0000\"},{\"id\":5,\"stepAction\":\"install-client-packages\",\"instanceId\":\"publish1uswest2\",\"updated\":\"2019-05-23T14:06:12.580+0000\"},{\"id\":6,\"stepAction\":\"install-client-packages\",\"instanceId\":\"author1uswest2\",\"updated\":\"2019-05-23T14:06:12.862+0000\"},{\"id\":7,\"stepAction\":\"manage-elb-links-attach\",\"instanceId\":\"dispatcher1uswest2\",\"updated\":\"2019-05-23T14:40:48.007+0000\"}]"
                 },
-                "status": "FINISHED"
+                "status": "FINISHED",
+                "_links": {
+                    "http://ns.adobe.com/adobecloud/rel/pipeline/logs": {
+                        "href": "/api/program/5/pipeline/7/execution/1001/phase/4597/step/8494/logs",
+                        "templated": false
+                    }
+                }
             },
             {
                 "id": "36518",
@@ -210,7 +226,13 @@
                         }
                     ]
                 },
-                "status": "NOT_STARTED"
+                "status": "NOT_STARTED",
+                "_links": {
+                    "http://ns.adobe.com/adobecloud/rel/pipeline/logs": {
+                        "href": "/api/program/5/pipeline/7/execution/1001/phase/4598/step/8500/logs",
+                        "templated": false
+                    }
+                }
             }
         ]
     },

--- a/test/__mocks__/node-fetch.js
+++ b/test/__mocks__/node-fetch.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 const nodeFetch = jest.requireActual('node-fetch');
 const fetchMock = require('fetch-mock').sandbox();
+const { Readable } = require('stream');
 Object.assign(fetchMock.config, nodeFetch, {
     fetch: nodeFetch
 });
@@ -251,6 +252,17 @@ mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/7/e
 mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4596/step/8493/metrics', 'GET', require('./data/metrics.json'))
 mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4597/step/8494/metrics', 'GET', {})
 mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4597/step/8495/metrics', 'GET', 404)
+mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4596/step/8493/logs', 'GET', {
+    redirect: 'https://somesite.com/log.txt'
+})
+const logResponse = new Readable()
+logResponse.push('some log line\n')
+logResponse.push('some other log line\n')
+logResponse.push(null)
+fetchMock.mock('https://somesite.com/log.txt', logResponse, { sendAsJson: false })
+mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4597/step/8494/logs', 'GET', 404)
+mockResponseWithMethod('https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4598/step/8500/logs', 'GET', {})
+
 
 let executionForPipeline7 = "1001"
 const pipeline7Executions = {

--- a/test/commands/get-execution-step-log.test.js
+++ b/test/commands/get-execution-step-log.test.js
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { setStore } = require('@adobe/aio-cna-core-config')
+const GetExecutionStepLog = require('../../src/commands/cloudmanager/get-execution-step-log')
+
+let capturedStdout
+let stdoutWriteToRestore;
+
+beforeEach(() => {
+    setStore({})
+    capturedStdout = ''
+    stdoutWriteToRestore = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk) => {
+        if (typeof chunk === 'string') {
+            capturedStdout += chunk;
+        } else if (Buffer.isBuffer(chunk)) {
+            capturedStdout += chunk.toString()
+        }
+    };
+})
+
+afterEach(() => {
+    process.stdout.write = stdoutWriteToRestore
+})
+
+test('get-execution-step-log - missing arg', async () => {
+    expect.assertions(2)
+
+    let runResult = GetExecutionStepLog.run([])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).rejects.toSatisfy(err => err.message.indexOf("Missing 3 required args") === 0)
+})
+
+test('get-execution-step-log - missing config', async () => {
+    expect.assertions(2)
+
+    let runResult = GetExecutionStepLog.run(["5", "--programId", "7", "1001", "codeQuality"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+})
+
+test('get-execution-step-log - failure', async () => {
+    setStore({
+        'jwt-auth': JSON.stringify({
+            client_id: '1234',
+            jwt_payload: {
+                iss: "good"
+            }
+        }),
+    })
+
+    expect.assertions(2)
+
+    let runResult = GetExecutionStepLog.run(["5", "--programId", "5", "1002", "codeQuality"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).rejects.toEqual(new Error('Cannot get execution: https://cloudmanager.adobe.io/api/program/5/pipeline/5/execution/1002 (404 Not Found)'))
+})
+
+test('get-execution-step-log - success', async () => {
+    setStore({
+        'jwt-auth': JSON.stringify({
+            client_id: '1234',
+            jwt_payload: {
+                iss: "good"
+            }
+        }),
+    })
+
+    expect.assertions(3)
+
+    let runResult = GetExecutionStepLog.run(["--programId", "5", "7", "1001", "codeQuality"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).resolves.toEqual({})
+    expect(capturedStdout).toEqual("some log line\nsome other log line\n")
+})
+
+test('get-execution-step-log - not found', async () => {
+    setStore({
+        'jwt-auth': JSON.stringify({
+            client_id: '1234',
+            jwt_payload: {
+                iss: "good"
+            }
+        }),
+    })
+
+    expect.assertions(2)
+
+    let runResult = GetExecutionStepLog.run(["--programId", "5", "7", "1001", "stageDeploy"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).rejects.toEqual(new Error("Cannot get log: https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4597/step/8494/logs (404 Not Found)"))
+})
+
+test('get-execution-step-log - empty', async () => {
+    setStore({
+        'jwt-auth': JSON.stringify({
+            client_id: '1234',
+            jwt_payload: {
+                iss: "good"
+            }
+        }),
+    })
+
+    expect.assertions(2)
+
+    let runResult = GetExecutionStepLog.run(["--programId", "5", "7", "1001", "prodDeploy"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).rejects.toEqual(new Error("Log https://cloudmanager.adobe.io/api/program/5/pipeline/7/execution/1001/phase/4598/step/8500/logs did not contain a redirect. Was {}."))
+})
+
+test('get-execution-step-log - missing step', async () => {
+    setStore({
+        'jwt-auth': JSON.stringify({
+            client_id: '1234',
+            jwt_payload: {
+                iss: "good"
+            }
+        }),
+    })
+
+    expect.assertions(2)
+
+    let runResult = GetExecutionStepLog.run(["--programId", "5", "7", "1003", "devDeploy"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).rejects.toEqual(new Error("Cannot find step state for action devDeploy on execution 1003."))
+})
+
+test('get-execution-step-log - bad pipeline', async () => {
+    setStore({
+        'jwt-auth': JSON.stringify({
+            client_id: '1234',
+            jwt_payload: {
+                iss: "good"
+            }
+        }),
+    })
+
+    expect.assertions(2)
+
+    let runResult = GetExecutionStepLog.run(["--programId", "5", "100", "1001", "build"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).rejects.toEqual(new Error("Cannot get execution. Pipeline 100 does not exist."))
+})
+


### PR DESCRIPTION
## Description

Adds the get-execution-step-logs command

## Related Issue

#16

## Motivation and Context

Nice to have easy access to step logs

## How Has This Been Tested?

* unit tests
* manual testing against real pipeline

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
