### PR TITLE
fix compatibility with node-fetch 8.3.0. fixes #70

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,9 +2076,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
-      "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
+      "integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ==",
       "dev": true
     },
     "core-util-is": {
@@ -3163,9 +3163,9 @@
       }
     },
     "fetch-mock": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-8.0.1.tgz",
-      "integrity": "sha512-omxXRmQJDWLbOpA907JMFNdjLkHAfOGIqcyS/1dJ/0EEyi19iIyYjT2nveT+4Nwmuh/HgRSsNwRl+HP690ZdGQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-8.3.1.tgz",
+      "integrity": "sha512-7IEIUvkHO6zOHbDSzkMAvkb2mx3N5xy9BS4RjFnIe8kCUDOomoNKBDKGwhTj5E0uuieo8rg55c6cUKorJuk4rg==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
-    "fetch-mock": "^8.0.0",
+    "fetch-mock": "^8.3.1",
     "jest": "^24.1.0",
     "jest-extended": "^0.11.1",
     "jest-haste-map": "^24.5.0",

--- a/test/__mocks__/node-fetch.js
+++ b/test/__mocks__/node-fetch.js
@@ -21,11 +21,11 @@ const _ = require('lodash')
 module.exports = fetchMock;
 
 function mockResponseWithOrgId(url, orgId, response) {
-    fetchMock.mock((u, { headers }) => u === url && headers['x-gw-ims-org-id'] === orgId, response)
+    fetchMock.mock({ url, headers: {"x-gw-ims-org-id" : orgId }, name: `${url}-org-id-${orgId}` }, response)
 }
 
 function mockResponseWithMethod(url, method, response) {
-    fetchMock.mock((u, opts) => u === url && opts.method === method, response)
+    fetchMock.mock({ url, method }, response)
 }
 
 mockResponseWithOrgId('https://cloudmanager.adobe.io/api/programs', 'not-found', 404)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

node-fetch 8.3.0 seems to have stricter checking of duplication of routes which this project uses for testing different org id headers.

## Related Issue

#70

## Motivation and Context

See #70

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
