### PR TITLE
check variable types before trying to delete. fixes #96

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -57,9 +57,9 @@ class Client {
                         debug(text)
                         if (res.ok) resolve(res)
                         else {
-                        const error = new Error(`${message}: ${res.url} (${res.status} ${res.statusText})`)
-                        error.res = res
-                        reject(error)
+                            const error = new Error(`${message}: ${res.url} (${res.status} ${res.statusText})`)
+                            error.res = res
+                            reject(error)
                         }
                     })
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Deleting a secretString variable requires sending the type along with the deletion request. Failure to do so results in an error.

Fixing this also has the nice side-effect of not trying to delete variables that don't exist (thus saving some API calls).

## Related Issue

#96 

## Motivation and Context

See bug report

## How Has This Been Tested?

Updated tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
