### PR TITLE
hide base environment variables command from README. fixes #101

### DIFF
--- a/src/base-environment-variables-command.js
+++ b/src/base-environment-variables-command.js
@@ -13,8 +13,8 @@ governing permissions and limitations under the License.
 const { Command } = require('@oclif/command')
 const { cli } = require('cli-ux')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId } = require('../../cloudmanager-helpers')
-const Client = require('../../client')
+const { getApiKey, getOrgId } = require('./cloudmanager-helpers')
+const Client = require('./client')
 
 async function _getEnvironmentVariables(programId, environmentId, passphrase) {
     const apiKey = await getApiKey()

--- a/src/commands/cloudmanager/list-environment-variables.js
+++ b/src/commands/cloudmanager/list-environment-variables.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const BaseEnvironmentVariablesCommand = require('./base-environment-variables-command')
+const BaseEnvironmentVariablesCommand = require('../../base-environment-variables-command')
 const { getProgramId } = require('../../cloudmanager-helpers')
 const commonFlags = require('../../common-flags')
 

--- a/src/commands/cloudmanager/set-environment-variables.js
+++ b/src/commands/cloudmanager/set-environment-variables.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const { flags } = require('@oclif/command')
-const BaseEnvironmentVariablesCommand = require('./base-environment-variables-command')
+const BaseEnvironmentVariablesCommand = require('../../base-environment-variables-command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
 const { getApiKey, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
 const { createKeyValueObjectFromFlag } = require('@adobe/aio-cli-plugin-runtime')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moved the file base-environment-variables-command.js from src/commands/cloudmanager to src. This seems to be the easiest way (without moving to TypeScript) to do fix the issue.

## Related Issue

#101 

## Motivation and Context

The readme is misleading

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
