### PR TITLE
migrate to aio-lib-ims. fixes #129

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,19 @@ $ aio plugins:update
 At minimum, an integration must be created in the [Adobe I/O Console](https://console.adobe.io) which has the Cloud Manager service. You may also add other services to this integration
 if you want to use other Adobe I/O CLI plugins. For example, to use the [Console Plugin](https://github.com/adobe/aio-cli-plugin-console/), your integration needs to have the "I/O Management API" service.
 
-After you've created the integration, create a `config.json` file on your computer and navigate to the integration Overview page. From this page, copy the `client_id` and `client_secret` values to the config file; if you navigate to the JWT tab in Console, you'll get the value for the `jwt_payload`.
+After you've created the integration, create a `config.json` file on your computer and navigate to the integration Overview page. From this page, copy the values into the file as described below.
 
 ```
 //config.json 
 {
   "client_id": "value from your CLI integration (String)",
   "client_secret": "value from your CLI integration (String)",
-  "jwt_payload": { value from your CLI integration (JSON Object Literal) },
-  "token_exchange_url": "https://ims-na1.adobelogin.com/ims/exchange/jwt"
+  "technical_account_id": "value from your CLI integration (String)",
+  "technical_account_email": "value from your CLI integration (String)",
+  "ims_org_id": "value from your CLI integration (String)",
+  "meta_scopes": [
+    "ent_cloudmgr_sdk"
+  ]
 }
 ```
 
@@ -61,16 +65,34 @@ The last bit you need to have at hand is the private certificate you've used to 
 First, configure the credentials:
 
 ```
-aio config:set jwt-auth PATH_TO_CONFIG_JSON_FILE --file --json
+aio config:set ims.contexts.aio-cli-plugin-cloudmanager PATH_TO_CONFIG_JSON_FILE --file --json
 ```
 
 Then, configure the private certificate:
 
 ```
-aio config:set jwt-auth.jwt_private_key PATH_TO_PRIVATE_KEY_FILE --file
+aio config:set ims.contexts.aio-cli-plugin-cloudmanager.private_key PATH_TO_PRIVATE_KEY_FILE --file
 ```
 
 > More information on setting up a Cloud Manager integration in the Adobe I/O console can be found [here](https://www.adobe.io/apis/experiencecloud/cloud-manager/docs.html#!AdobeDocs/cloudmanager-api-docs/master/create-api-integration.md).
+
+> More information on IMS contexts can be found in the documentation of [@adobe/aio-lib-ims](https://github.com/adobe/aio-lib-ims).
+
+### Old Configuration Migration
+
+Previous versions of this plugin used the configuration key `jwt-auth`. Upon execution, the plugin will automatically migrate these configurations. It will **not** delete the old configuration however and you may want to run
+
+```
+aio config:del jwt-auth
+```
+
+To clean up any dangling configuration unless it is necessary for other aio plugins.
+
+This migration process is silent by default. You can enable debug logging by running any command where the environment variable `LOG_LEVEL` is set to `debug`, e.g.
+
+```
+LOG_LEVEL=debug aio cloudmanager:list-programs
+```
 
 ## Set Default Program
 
@@ -150,8 +172,8 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:advance-current-execution
@@ -171,8 +193,8 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:cancel-current-execution
@@ -192,10 +214,10 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:get-current-execution
@@ -217,8 +239,8 @@ ARGUMENTS
   SERVICE        (author|publish) the service name
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/environment/bind-ip-allowlist.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/environment/bind-ip-allowlist.js)_
@@ -235,8 +257,8 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:delete-environment
@@ -264,7 +286,7 @@ OPTIONS
   -p, --programId=programId              the programId. if not specified, defaults to 'cloudmanager_programid' config
                                          value
 
-  -r, --passphrase=passphrase            the passphrase for the private key
+  --imsContextName=imsContextName        the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:download-logs
@@ -284,10 +306,10 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:list-available-log-options
@@ -307,10 +329,10 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:environment:list-bound-ip-allowlists
@@ -330,10 +352,10 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:list-environment-variables
@@ -353,8 +375,8 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:open-developer-console
@@ -374,19 +396,19 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
-  -d, --delete=delete          variables/secrets to delete
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -s, --secret=secret          secret values in KEY VALUE format
-  -v, --variable=variable      variable values in KEY VALUE format
-  -y, --yaml                   output in yaml format
+  -d, --delete=delete              variables/secrets to delete
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -s, --secret=secret              secret values in KEY VALUE format
+  -v, --variable=variable          variable values in KEY VALUE format
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
-  --jsonFile=jsonFile          if set, read variables from a JSON array provided as a file; variables set through
-                               --variable or --secret flag will take precedence
+  --jsonFile=jsonFile              if set, read variables from a JSON array provided as a file; variables set through
+                                   --variable or --secret flag will take precedence
 
-  --jsonStdin                  if set, read variables from a JSON array provided as standard input; variables set
-                               through --variable or --secret flag will take precedence
+  --jsonStdin                      if set, read variables from a JSON array provided as standard input; variables set
+                                   through --variable or --secret flag will take precedence
 
 ALIASES
   $ aio cloudmanager:set-environment-variables
@@ -408,8 +430,8 @@ ARGUMENTS
   NAME           the log name
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:tail-logs
@@ -432,8 +454,8 @@ ARGUMENTS
   SERVICE        (author|publish) the service name
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/environment/unbind-ip-allowlist.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/environment/unbind-ip-allowlist.js)_
@@ -452,10 +474,10 @@ ARGUMENTS
   ACTION       (codeQuality|security|performance|contentAudit|experienceAudit) the step action
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:get-quality-gate-results
@@ -476,10 +498,10 @@ ARGUMENTS
   EXECUTIONID  the execution id
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:get-execution-step-details
@@ -501,14 +523,14 @@ ARGUMENTS
   ACTION       (build|codeQuality|devDeploy|stageDeploy|prodDeploy|buildImage) the step action
 
 OPTIONS
-  -f, --file=file              the alternative log file name. currently only `sonarLogFile` is available (for the
-                               codeQuality step)
+  -f, --file=file                  the alternative log file name. currently only `sonarLogFile` is available (for the
+                                   codeQuality step)
 
-  -o, --output=output          the output file. If not set, uses standard output.
+  -o, --output=output              the output file. If not set, uses standard output.
 
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
 
-  -r, --passphrase=passphrase  the passphrase for the private key
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:get-execution-step-log
@@ -530,8 +552,8 @@ ARGUMENTS
   SERVICE        (author|publish) the service name
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/ip-allowlist/bind.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/ip-allowlist/bind.js)_
@@ -548,9 +570,9 @@ ARGUMENTS
   NAME  the name to create
 
 OPTIONS
-  -c, --cidr=cidr              (required) a CIDR block
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -c, --cidr=cidr                  (required) a CIDR block
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/ip-allowlist/create.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/ip-allowlist/create.js)_
@@ -567,8 +589,8 @@ ARGUMENTS
   IPALLOWLISTID  the id of the allowlist to delete
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/ip-allowlist/delete.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/ip-allowlist/delete.js)_
@@ -585,10 +607,10 @@ ARGUMENTS
   IPALLOWLISTID  the id of the allowlist
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/ip-allowlist/get-binding-details.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/ip-allowlist/get-binding-details.js)_
@@ -607,8 +629,8 @@ ARGUMENTS
   SERVICE        (author|publish) the service name
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/ip-allowlist/unbind.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/ip-allowlist/unbind.js)_
@@ -625,11 +647,11 @@ ARGUMENTS
   IPALLOWLISTID  the id of the allowlist to update
 
 OPTIONS
-  -c, --cidr=cidr              (required) a CIDR block
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -c, --cidr=cidr                  (required) a CIDR block
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/ip-allowlist/update.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/ip-allowlist/update.js)_
@@ -643,10 +665,10 @@ USAGE
   $ aio cloudmanager:list-programs
 
 OPTIONS
-  -e, --enabledonly            only output Cloud Manager-enabled programs
-  -j, --json                   output in json format
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -e, --enabledonly                only output Cloud Manager-enabled programs
+  -j, --json                       output in json format
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/list-programs.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/list-programs.js)_
@@ -663,8 +685,8 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:create-execution
@@ -685,8 +707,8 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:delete-pipeline
@@ -706,10 +728,10 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:list-pipeline-variables
@@ -729,19 +751,19 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -d, --delete=delete          variables/secrets to delete
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -s, --secret=secret          secret values in KEY VALUE format
-  -v, --variable=variable      variable values in KEY VALUE format
-  -y, --yaml                   output in yaml format
+  -d, --delete=delete              variables/secrets to delete
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -s, --secret=secret              secret values in KEY VALUE format
+  -v, --variable=variable          variable values in KEY VALUE format
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
-  --jsonFile=jsonFile          if set, read variables from a JSON array provided as a file; variables set through
-                               --variable or --secret flag will take precedence
+  --jsonFile=jsonFile              if set, read variables from a JSON array provided as a file; variables set through
+                                   --variable or --secret flag will take precedence
 
-  --jsonStdin                  if set, read variables from a JSON array provided as standard input; variables set
-                               through --variable or --secret flag will take precedence
+  --jsonStdin                      if set, read variables from a JSON array provided as standard input; variables set
+                                   through --variable or --secret flag will take precedence
 
 ALIASES
   $ aio cloudmanager:set-pipeline-variables
@@ -761,11 +783,11 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  --branch=branch              the new branch
-  --repositoryId=repositoryId  the new repositoryId
-  --tag=tag                    the new tag
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  --branch=branch                  the new branch
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
+  --repositoryId=repositoryId      the new repositoryId
+  --tag=tag                        the new tag
 
 ALIASES
   $ aio cloudmanager:update-pipeline
@@ -785,7 +807,7 @@ ARGUMENTS
   PROGRAMID  the program id
 
 OPTIONS
-  -r, --passphrase=passphrase  the passphrase for the private key
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:delete-program
@@ -802,10 +824,10 @@ USAGE
   $ aio cloudmanager:program:list-current-executions
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:list-current-executions
@@ -822,10 +844,10 @@ USAGE
   $ aio cloudmanager:program:list-environments
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:list-environments
@@ -842,10 +864,10 @@ USAGE
   $ aio cloudmanager:program:list-ip-allowlists
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 ```
 
 _See code: [src/commands/cloudmanager/program/list-ip-allowlists.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.19.0/src/commands/cloudmanager/program/list-ip-allowlists.js)_
@@ -859,10 +881,10 @@ USAGE
   $ aio cloudmanager:program:list-pipelines
 
 OPTIONS
-  -j, --json                   output in json format
-  -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -r, --passphrase=passphrase  the passphrase for the private key
-  -y, --yaml                   output in yaml format
+  -j, --json                       output in json format
+  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -y, --yaml                       output in yaml format
+  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
 ALIASES
   $ aio cloudmanager:list-pipelines

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-cloudmanager/issues",
   "dependencies": {
-    "@adobe/aio-cli-plugin-jwt-auth": "^2.0.1",
     "@adobe/aio-lib-cloudmanager": "^0.2.0",
     "@adobe/aio-lib-core-config": "^2.0.0",
+    "@adobe/aio-lib-core-logging": "^1.2.0",
+    "@adobe/aio-lib-ims": "^4.1.1",
     "@oclif/command": "^1.6.1",
     "@oclif/config": "^1.15.1",
     "@oclif/parser": "^3.8.5",
@@ -63,7 +64,8 @@
     ],
     "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>",
     "hooks": {
-      "prerun": "./src/hooks/prerun/environment-id-from-config"
+      "prerun": "./src/hooks/prerun/environment-id-from-config",
+      "init": "./src/hooks/init/migrate-jwt-context-hook.js"
     },
     "topics": {
       "cloudmanager": {

--- a/src/base-environment-variables-command.js
+++ b/src/base-environment-variables-command.js
@@ -10,24 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, sanitizeEnvironmentId } = require('./cloudmanager-helpers')
+const { initSdk, sanitizeEnvironmentId } = require('./cloudmanager-helpers')
 const BaseVariablesCommand = require('./base-variables-command')
-const { init } = require('@adobe/aio-lib-cloudmanager')
-
-async function _getEnvironmentVariables (programId, environmentId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.getEnvironmentVariables(programId, environmentId)
-}
 
 class BaseEnvironmentVariablesCommand extends BaseVariablesCommand {
-  async getVariables (programId, args, passphrase = null) {
+  async getVariables (programId, args, imsContextName = null) {
     const environmentId = sanitizeEnvironmentId(args.environmentId)
-    return _getEnvironmentVariables(programId, environmentId, passphrase)
+    const sdk = await initSdk(imsContextName)
+    return sdk.getEnvironmentVariables(programId, environmentId)
   }
 }
 

--- a/src/base-pipeline-variables-command.js
+++ b/src/base-pipeline-variables-command.js
@@ -10,23 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId } = require('./cloudmanager-helpers')
+const { initSdk } = require('./cloudmanager-helpers')
 const BaseVariablesCommand = require('./base-variables-command')
-const { init } = require('@adobe/aio-lib-cloudmanager')
-
-async function _getPipelineVariables (programId, pipelineId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.getPipelineVariables(programId, pipelineId)
-}
 
 class BasePipelineVariablesCommand extends BaseVariablesCommand {
-  async getVariables (programId, args, passphrase = null) {
-    return _getPipelineVariables(programId, args.pipelineId, passphrase)
+  async getVariables (programId, args, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.getPipelineVariables(programId, args.pipelineId)
   }
 }
 

--- a/src/base-variables-command.js
+++ b/src/base-variables-command.js
@@ -37,13 +37,13 @@ class BaseVariablesCommand extends Command {
   async runSet (args, flags) {
     const programId = await getProgramId(flags)
 
-    const currentVariablesList = await this.getVariables(programId, args, flags.passphrase)
+    const currentVariablesList = await this.getVariables(programId, args, flags.imsContextName)
 
     const variables = await this.prepareVariableList(flags, currentVariablesList)
 
     if (variables.length > 0) {
       cli.action.start('setting variables')
-      await this.setVariables(programId, args, variables, flags.passphrase)
+      await this.setVariables(programId, args, variables, flags.imsContextName)
       cli.action.stop()
     } else {
       this.log('No variables to set or delete.')
@@ -52,7 +52,7 @@ class BaseVariablesCommand extends Command {
     let result
 
     try {
-      result = await this.getVariables(programId, args, flags.passphrase)
+      result = await this.getVariables(programId, args, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/current-execution/advance.js
+++ b/src/commands/cloudmanager/current-execution/advance.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _advanceCurrentExecution (programId, pipelineId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.advanceCurrentExecution(programId, pipelineId)
-}
 
 class AdvanceCurrentExecutionCommand extends Command {
   async run () {
@@ -37,7 +26,7 @@ class AdvanceCurrentExecutionCommand extends Command {
     cli.action.start('advancing execution')
 
     try {
-      result = await this.advanceCurrentExecution(programId, args.pipelineId, flags.passphrase)
+      result = await this.advanceCurrentExecution(programId, args.pipelineId, flags.imsContextName)
     } catch (error) {
       cli.action.stop(error.message)
       return
@@ -48,8 +37,9 @@ class AdvanceCurrentExecutionCommand extends Command {
     return result
   }
 
-  async advanceCurrentExecution (programId, pipelineId, passphrase = null) {
-    return _advanceCurrentExecution(programId, pipelineId, passphrase)
+  async advanceCurrentExecution (programId, pipelineId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.advanceCurrentExecution(programId, pipelineId)
   }
 }
 

--- a/src/commands/cloudmanager/current-execution/cancel.js
+++ b/src/commands/cloudmanager/current-execution/cancel.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _cancelCurrentExecution (programId, pipelineId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.cancelCurrentExecution(programId, pipelineId)
-}
 
 class CancelCurrentExecutionCommand extends Command {
   async run () {
@@ -37,7 +26,7 @@ class CancelCurrentExecutionCommand extends Command {
     cli.action.start('cancelling execution')
 
     try {
-      result = await this.cancelCurrentExecution(programId, args.pipelineId, flags.passphrase)
+      result = await this.cancelCurrentExecution(programId, args.pipelineId, flags.imsContextName)
     } catch (error) {
       cli.action.stop(error.message)
       return
@@ -48,8 +37,9 @@ class CancelCurrentExecutionCommand extends Command {
     return result
   }
 
-  async cancelCurrentExecution (programId, pipelineId, passphrase = null) {
-    return _cancelCurrentExecution(programId, pipelineId, passphrase)
+  async cancelCurrentExecution (programId, pipelineId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.cancelCurrentExecution(programId, pipelineId)
   }
 }
 

--- a/src/commands/cloudmanager/current-execution/get.js
+++ b/src/commands/cloudmanager/current-execution/get.js
@@ -10,20 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
-const { init } = require('@adobe/aio-lib-cloudmanager')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
 const BaseExecutionCommand = require('../../../base-execution-command')
-
-async function _getCurrentExecution (programId, pipelineId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.getCurrentExecution(programId, pipelineId)
-}
 
 class GetCurrentExecutionCommand extends BaseExecutionCommand {
   async run () {
@@ -34,7 +23,7 @@ class GetCurrentExecutionCommand extends BaseExecutionCommand {
     let result
 
     try {
-      result = await this.getCurrentExecution(programId, args.pipelineId, flags.passphrase)
+      result = await this.getCurrentExecution(programId, args.pipelineId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -44,8 +33,9 @@ class GetCurrentExecutionCommand extends BaseExecutionCommand {
     return result
   }
 
-  async getCurrentExecution (programId, pipelineId, passphrase = null) {
-    return _getCurrentExecution(programId, pipelineId, passphrase)
+  async getCurrentExecution (programId, pipelineId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.getCurrentExecution(programId, pipelineId)
   }
 }
 

--- a/src/commands/cloudmanager/environment/bind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/bind-ip-allowlist.js
@@ -28,7 +28,7 @@ class BindIPAllowlist extends Command {
     let result
 
     try {
-      result = await new CoreBindIPAllowlist().bindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.passphrase)
+      result = await new CoreBindIPAllowlist().bindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/environment/delete.js
+++ b/src/commands/cloudmanager/environment/delete.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _deleteEnvironment (programId, environmentId, passphrase) {
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.deleteEnvironment(programId, environmentId)
-}
 
 class DeleteEnvironmentCommand extends Command {
   async run () {
@@ -39,7 +28,7 @@ class DeleteEnvironmentCommand extends Command {
     cli.action.start('deleting environment')
 
     try {
-      result = await this.deleteEnvironment(programId, environmentId, flags.passphrase)
+      result = await this.deleteEnvironment(programId, environmentId, flags.imsContextName)
       cli.action.stop(`deleted environment ID ${environmentId}`)
     } catch (error) {
       cli.action.stop(error.message)
@@ -49,8 +38,9 @@ class DeleteEnvironmentCommand extends Command {
     return result
   }
 
-  async deleteEnvironment (programId, environmentId, passphrase = null) {
-    return _deleteEnvironment(programId, environmentId, passphrase)
+  async deleteEnvironment (programId, environmentId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.deleteEnvironment(programId, environmentId)
   }
 }
 

--- a/src/commands/cloudmanager/environment/download-logs.js
+++ b/src/commands/cloudmanager/environment/download-logs.js
@@ -11,21 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const { Command, flags } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const path = require('path')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _downloadLogs (programId, environmentId, service, logName, days, outputDirectory, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.downloadLogs(programId, environmentId, service, logName, days, outputDirectory)
-}
 
 class DownloadLogs extends Command {
   async run () {
@@ -42,7 +31,7 @@ class DownloadLogs extends Command {
     let result
 
     try {
-      result = await this.downloadLogs(programId, environmentId, args.service, args.name, args.days, outputDirectory, flags.passphrase)
+      result = await this.downloadLogs(programId, environmentId, args.service, args.name, args.days, outputDirectory, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -64,8 +53,9 @@ class DownloadLogs extends Command {
     return result
   }
 
-  async downloadLogs (programId, environmentId, service, name, days, outputDirectory, passphrase = null) {
-    return _downloadLogs(programId, environmentId, service, name, days, outputDirectory, passphrase)
+  async downloadLogs (programId, environmentId, service, logName, days, outputDirectory, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.downloadLogs(programId, environmentId, service, logName, days, outputDirectory)
   }
 }
 

--- a/src/commands/cloudmanager/environment/list-available-log-options.js
+++ b/src/commands/cloudmanager/environment/list-available-log-options.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId, getOutputFormat } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, sanitizeEnvironmentId, getOutputFormat } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _listAvailableLogOptions (programId, environmentId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.listAvailableLogOptions(programId, environmentId)
-}
 
 class ListAvailableLogOptionsCommand extends Command {
   async run () {
@@ -37,7 +26,7 @@ class ListAvailableLogOptionsCommand extends Command {
     let result
 
     try {
-      result = await this.listAvailableLogOptions(programId, environmentId, flags.passphrase)
+      result = await this.listAvailableLogOptions(programId, environmentId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -61,8 +50,9 @@ class ListAvailableLogOptionsCommand extends Command {
     return result
   }
 
-  async listAvailableLogOptions (programId, environmentId, passphrase = null) {
-    return _listAvailableLogOptions(programId, environmentId, passphrase)
+  async listAvailableLogOptions (programId, environmentId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.listAvailableLogOptions(programId, environmentId)
   }
 }
 

--- a/src/commands/cloudmanager/environment/list-ip-allowlist-bindings.js
+++ b/src/commands/cloudmanager/environment/list-ip-allowlist-bindings.js
@@ -26,7 +26,7 @@ class ListIPAllowlistBindings extends Command {
     let result
 
     try {
-      result = await new ListIpAllowlists().listIpAllowlists(programId, flags.passphrase)
+      result = await new ListIpAllowlists().listIpAllowlists(programId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/environment/list-variables.js
+++ b/src/commands/cloudmanager/environment/list-variables.js
@@ -24,7 +24,7 @@ class ListEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
     let result
 
     try {
-      result = await this.getVariables(programId, args, flags.passphrase)
+      result = await this.getVariables(programId, args, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/environment/open-developer-console.js
+++ b/src/commands/cloudmanager/environment/open-developer-console.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _getDeveloperConsoleUrl (programId, environmentId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.getDeveloperConsoleUrl(programId, environmentId)
-}
 
 class OpenDeveloperConsoleCommand extends Command {
   async run () {
@@ -37,7 +26,7 @@ class OpenDeveloperConsoleCommand extends Command {
     let result
 
     try {
-      result = await this.getDeveloperConsoleUrl(programId, environmentId, flags.passphrase)
+      result = await this.getDeveloperConsoleUrl(programId, environmentId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -47,8 +36,9 @@ class OpenDeveloperConsoleCommand extends Command {
     return result
   }
 
-  async getDeveloperConsoleUrl (programId, environmentId, passphrase = null) {
-    return _getDeveloperConsoleUrl(programId, environmentId, passphrase)
+  async getDeveloperConsoleUrl (programId, environmentId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.getDeveloperConsoleUrl(programId, environmentId)
   }
 }
 

--- a/src/commands/cloudmanager/environment/set-variables.js
+++ b/src/commands/cloudmanager/environment/set-variables.js
@@ -12,19 +12,8 @@ governing permissions and limitations under the License.
 
 const BaseEnvironmentVariablesCommand = require('../../../base-environment-variables-command')
 const BaseVariablesCommand = require('../../../base-variables-command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
-const { init } = require('@adobe/aio-lib-cloudmanager')
+const { initSdk, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
-
-async function _setEnvironmentVariables (programId, environmentId, variables, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.setEnvironmentVariables(programId, environmentId, variables)
-}
 
 class SetEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
   async run () {
@@ -33,9 +22,10 @@ class SetEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
     return this.runSet(args, flags)
   }
 
-  async setVariables (programId, args, variables, passphrase = null) {
+  async setVariables (programId, args, variables, imsContextName = null) {
     const environmentId = sanitizeEnvironmentId(args.environmentId)
-    return _setEnvironmentVariables(programId, environmentId, variables, passphrase)
+    const sdk = await initSdk(imsContextName)
+    return sdk.setEnvironmentVariables(programId, environmentId, variables)
   }
 }
 

--- a/src/commands/cloudmanager/environment/tail-log.js
+++ b/src/commands/cloudmanager/environment/tail-log.js
@@ -11,19 +11,8 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
-const { init } = require('@adobe/aio-lib-cloudmanager')
+const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
-
-async function _tailLog (programId, environmentId, service, logName, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.tailLog(programId, environmentId, service, logName, process.stdout)
-}
 
 class TailLog extends Command {
   async run () {
@@ -36,7 +25,7 @@ class TailLog extends Command {
     let result
 
     try {
-      result = await this.tailLog(programId, environmentId, args.service, args.name, flags.passphrase)
+      result = await this.tailLog(programId, environmentId, args.service, args.name, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -46,8 +35,9 @@ class TailLog extends Command {
     return result
   }
 
-  async tailLog (programId, environmentId, service, name, passphrase = null) {
-    return _tailLog(programId, environmentId, service, name, passphrase)
+  async tailLog (programId, environmentId, service, logName, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.tailLog(programId, environmentId, service, logName, process.stdout)
   }
 }
 

--- a/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
@@ -28,7 +28,7 @@ class UnbindIPAllowlist extends Command {
     let result
 
     try {
-      result = await new CoreUnbindIPAllowlist().unbindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.passphrase)
+      result = await new CoreUnbindIPAllowlist().unbindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/execution/get-quality-gate-results.js
+++ b/src/commands/cloudmanager/execution/get-quality-gate-results.js
@@ -11,24 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const _ = require('lodash')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _getQualityGateResults (programId, pipelineId, executionId, action, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  if (action === 'experienceAudit') {
-    action = 'contentAudit'
-  }
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.getQualityGateResults(programId, pipelineId, executionId, action)
-}
 
 function formatMetricName (name) {
   switch (name) {
@@ -49,7 +35,7 @@ class GetQualityGateResults extends Command {
     let result
 
     try {
-      result = await this.getQualityGateResults(programId, args.pipelineId, args.executionId, args.action, flags.passphrase)
+      result = await this.getQualityGateResults(programId, args.pipelineId, args.executionId, args.action, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -89,8 +75,12 @@ class GetQualityGateResults extends Command {
     return result
   }
 
-  async getQualityGateResults (programId, pipelineId, executionId, action, passphrase = null) {
-    return _getQualityGateResults(programId, pipelineId, executionId, action, passphrase)
+  async getQualityGateResults (programId, pipelineId, executionId, action, imsContextName = null) {
+    if (action === 'experienceAudit') {
+      action = 'contentAudit'
+    }
+    const sdk = await initSdk(imsContextName)
+    return sdk.getQualityGateResults(programId, pipelineId, executionId, action)
   }
 }
 

--- a/src/commands/cloudmanager/execution/get-step-details.js
+++ b/src/commands/cloudmanager/execution/get-step-details.js
@@ -11,23 +11,12 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const _ = require('lodash')
 const halfred = require('halfred')
 const moment = require('moment')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _getExecution (programId, pipelineId, executionId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.getExecution(programId, pipelineId, executionId)
-}
 
 function formatAction (stepState) {
   if (stepState.action === 'deploy') {
@@ -58,7 +47,7 @@ class GetExecutionStepDetails extends Command {
     let result
 
     try {
-      result = await this.getExecution(programId, args.pipelineId, args.executionId, flags.passphrase)
+      result = await this.getExecution(programId, args.pipelineId, args.executionId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -104,8 +93,9 @@ class GetExecutionStepDetails extends Command {
     return result
   }
 
-  async getExecution (programId, pipelineId, executionId, passphrase = null) {
-    return _getExecution(programId, pipelineId, executionId, passphrase)
+  async getExecution (programId, pipelineId, executionId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.getExecution(programId, pipelineId, executionId)
   }
 }
 

--- a/src/commands/cloudmanager/execution/get-step-log.js
+++ b/src/commands/cloudmanager/execution/get-step-log.js
@@ -13,19 +13,8 @@ governing permissions and limitations under the License.
 const { Command, flags } = require('@oclif/command')
 const fs = require('fs')
 const { cli } = require('cli-ux')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
-const { init } = require('@adobe/aio-lib-cloudmanager')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
-
-async function _getExecutionStepLog (programId, pipelineId, executionId, action, logFile, outputStream, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.getExecutionStepLog(programId, pipelineId, executionId, action, logFile, outputStream)
-}
 
 class GetExecutionStepLogs extends Command {
   async run () {
@@ -42,7 +31,7 @@ class GetExecutionStepLogs extends Command {
     let result
 
     try {
-      result = await this.getExecutionStepLog(programId, args.pipelineId, args.executionId, args.action, flags.file, outputStream, flags.passphrase)
+      result = await this.getExecutionStepLog(programId, args.pipelineId, args.executionId, args.action, flags.file, outputStream, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -54,8 +43,9 @@ class GetExecutionStepLogs extends Command {
     return result
   }
 
-  async getExecutionStepLog (programId, pipelineId, executionId, action, outputStream, passphrase = null) {
-    return _getExecutionStepLog(programId, pipelineId, executionId, action, outputStream, passphrase)
+  async getExecutionStepLog (programId, pipelineId, executionId, action, logFile, outputStream, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.getExecutionStepLog(programId, pipelineId, executionId, action, logFile, outputStream)
   }
 }
 

--- a/src/commands/cloudmanager/ip-allowlist/bind.js
+++ b/src/commands/cloudmanager/ip-allowlist/bind.js
@@ -11,21 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
 const commonArgs = require('../../../common-args')
-
-async function _bindIpAllowlist (programId, ipAllowlistId, environmentId, service, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.addIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)
-}
 
 class BindIPAllowlist extends Command {
   async run () {
@@ -38,7 +27,7 @@ class BindIPAllowlist extends Command {
     let result
 
     try {
-      result = await this.bindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.passphrase)
+      result = await this.bindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -48,8 +37,9 @@ class BindIPAllowlist extends Command {
     return result
   }
 
-  async bindIpAllowlist (programId, ipAllowlistId, environmentId, service, passphrase = null) {
-    return _bindIpAllowlist(programId, ipAllowlistId, environmentId, service, passphrase)
+  async bindIpAllowlist (programId, ipAllowlistId, environmentId, service, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.addIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)
   }
 }
 

--- a/src/commands/cloudmanager/ip-allowlist/create.js
+++ b/src/commands/cloudmanager/ip-allowlist/create.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command, flags } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _createIpAllowlist (programId, name, cidrBlocks, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.createIpAllowlist(programId, name, cidrBlocks)
-}
 
 class CreateIPAllowlist extends Command {
   async run () {
@@ -37,7 +26,7 @@ class CreateIPAllowlist extends Command {
     let result
 
     try {
-      result = await this.createIpAllowlist(programId, args.name, flags.cidr, flags.passphrase)
+      result = await this.createIpAllowlist(programId, args.name, flags.cidr, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -47,8 +36,9 @@ class CreateIPAllowlist extends Command {
     return result
   }
 
-  async createIpAllowlist (programId, name, blocks, passphrase = null) {
-    return _createIpAllowlist(programId, name, blocks, passphrase)
+  async createIpAllowlist (programId, name, cidrBlocks, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.createIpAllowlist(programId, name, cidrBlocks)
   }
 }
 

--- a/src/commands/cloudmanager/ip-allowlist/delete.js
+++ b/src/commands/cloudmanager/ip-allowlist/delete.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _deleteIpAllowlist (programId, ipAllowlistId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.deleteIpAllowlist(programId, ipAllowlistId)
-}
 
 class DeleteIPAllowlist extends Command {
   async run () {
@@ -37,7 +26,7 @@ class DeleteIPAllowlist extends Command {
     let result
 
     try {
-      result = await this.deleteIpAllowlist(programId, args.ipAllowlistId, flags.passphrase)
+      result = await this.deleteIpAllowlist(programId, args.ipAllowlistId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -47,8 +36,9 @@ class DeleteIPAllowlist extends Command {
     return result
   }
 
-  async deleteIpAllowlist (programId, ipAllowlistId, passphrase = null) {
-    return _deleteIpAllowlist(programId, ipAllowlistId, passphrase)
+  async deleteIpAllowlist (programId, ipAllowlistId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.deleteIpAllowlist(programId, ipAllowlistId)
   }
 }
 

--- a/src/commands/cloudmanager/ip-allowlist/get-binding-details.js
+++ b/src/commands/cloudmanager/ip-allowlist/get-binding-details.js
@@ -11,22 +11,11 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const _ = require('lodash')
 const commonFlags = require('../../../common-flags')
 const ListEnvironmentsCommand = require('./../program/list-environments')
-
-async function _listIpAllowlists (programId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.listIpAllowlists(programId)
-}
 
 class ListIPAllowlistBindingDetails extends Command {
   async run () {
@@ -37,7 +26,7 @@ class ListIPAllowlistBindingDetails extends Command {
     let result
 
     try {
-      result = await this.listIpAllowlists(programId, flags.passphrase)
+      result = await this.listIpAllowlists(programId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -52,7 +41,7 @@ class ListIPAllowlistBindingDetails extends Command {
 
     let environments
     try {
-      environments = await new ListEnvironmentsCommand().listEnvironments(programId, flags.passphrase)
+      environments = await new ListEnvironmentsCommand().listEnvironments(programId, flags.imsContextName)
     } catch (error) {
     }
 
@@ -87,8 +76,9 @@ class ListIPAllowlistBindingDetails extends Command {
     return allowList
   }
 
-  async listIpAllowlists (programId, passphrase = null) {
-    return _listIpAllowlists(programId, passphrase)
+  async listIpAllowlists (programId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.listIpAllowlists(programId)
   }
 }
 

--- a/src/commands/cloudmanager/ip-allowlist/unbind.js
+++ b/src/commands/cloudmanager/ip-allowlist/unbind.js
@@ -11,21 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
 const commonArgs = require('../../../common-args')
-
-async function _unbindIpAllowlist (programId, ipAllowlistId, environmentId, service, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.removeIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)
-}
 
 class UnbindIPAllowlist extends Command {
   async run () {
@@ -38,7 +27,7 @@ class UnbindIPAllowlist extends Command {
     let result
 
     try {
-      result = await this.unbindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.passphrase)
+      result = await this.unbindIpAllowlist(programId, args.ipAllowlistId, args.environmentId, args.service, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -48,8 +37,9 @@ class UnbindIPAllowlist extends Command {
     return result
   }
 
-  async unbindIpAllowlist (programId, ipAllowlistId, environmentId, service, passphrase = null) {
-    return _unbindIpAllowlist(programId, ipAllowlistId, environmentId, service, passphrase)
+  async unbindIpAllowlist (programId, ipAllowlistId, environmentId, service, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.removeIpAllowlistBinding(programId, ipAllowlistId, environmentId, service)
   }
 }
 

--- a/src/commands/cloudmanager/ip-allowlist/update.js
+++ b/src/commands/cloudmanager/ip-allowlist/update.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command, flags } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _updateIpAllowlist (programId, ipAllowlistId, blocks, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.updateIpAllowlist(programId, ipAllowlistId, blocks)
-}
 
 class UpdateIPAllowlist extends Command {
   async run () {
@@ -37,7 +26,7 @@ class UpdateIPAllowlist extends Command {
     let result
 
     try {
-      result = await this.updateIpAllowlist(programId, args.ipAllowlistId, flags.cidr, flags.passphrase)
+      result = await this.updateIpAllowlist(programId, args.ipAllowlistId, flags.cidr, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -47,8 +36,9 @@ class UpdateIPAllowlist extends Command {
     return result
   }
 
-  async updateIpAllowlist (programId, ipAllowlistId, blocks, passphrase = null) {
-    return _updateIpAllowlist(programId, ipAllowlistId, blocks, passphrase)
+  async updateIpAllowlist (programId, ipAllowlistId, blocks, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.updateIpAllowlist(programId, ipAllowlistId, blocks)
   }
 }
 

--- a/src/commands/cloudmanager/list-programs.js
+++ b/src/commands/cloudmanager/list-programs.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command, flags } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getOutputFormat } = require('../../cloudmanager-helpers')
-const { init } = require('@adobe/aio-lib-cloudmanager')
+const { initSdk, getOutputFormat } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const commonFlags = require('../../common-flags')
-
-async function _listPrograms (passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.listPrograms()
-}
 
 class ListProgramsCommand extends Command {
   async run () {
@@ -32,7 +21,7 @@ class ListProgramsCommand extends Command {
     let result
 
     try {
-      result = await this.listPrograms(flags.passphrase)
+      result = await this.listPrograms(flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -55,8 +44,9 @@ class ListProgramsCommand extends Command {
     return result
   }
 
-  async listPrograms (passphrase = null) {
-    return _listPrograms(passphrase)
+  async listPrograms (imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.listPrograms()
   }
 }
 

--- a/src/commands/cloudmanager/pipeline/create-execution.js
+++ b/src/commands/cloudmanager/pipeline/create-execution.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _startExecution (programId, pipelineId, passphrase) {
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.createExecution(programId, pipelineId)
-}
 
 class StartExecutionCommand extends Command {
   async run () {
@@ -37,7 +26,7 @@ class StartExecutionCommand extends Command {
     cli.action.start('starting execution')
 
     try {
-      result = await this.startExecution(programId, args.pipelineId, flags.passphrase)
+      result = await this.startExecution(programId, args.pipelineId, flags.imsContextName)
     } catch (error) {
       cli.action.stop(error.message)
       return
@@ -48,8 +37,9 @@ class StartExecutionCommand extends Command {
     return result
   }
 
-  async startExecution (programId, pipelineId, passphrase = null) {
-    return _startExecution(programId, pipelineId, passphrase)
+  async startExecution (programId, pipelineId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.createExecution(programId, pipelineId)
   }
 }
 

--- a/src/commands/cloudmanager/pipeline/delete.js
+++ b/src/commands/cloudmanager/pipeline/delete.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _deletePipeline (programId, pipelineId, passphrase) {
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.deletePipeline(programId, pipelineId)
-}
 
 class DeletePipelineCommand extends Command {
   async run () {
@@ -37,7 +26,7 @@ class DeletePipelineCommand extends Command {
     cli.action.start('deleting pipeline')
 
     try {
-      result = await this.deletePipeline(programId, args.pipelineId, flags.passphrase)
+      result = await this.deletePipeline(programId, args.pipelineId, flags.imsContextName)
       cli.action.stop(`deleted pipeline ID ${args.pipelineId}`)
     } catch (error) {
       cli.action.stop(error.message)
@@ -47,8 +36,9 @@ class DeletePipelineCommand extends Command {
     return result
   }
 
-  async deletePipeline (programId, pipelineId, passphrase = null) {
-    return _deletePipeline(programId, pipelineId, passphrase)
+  async deletePipeline (programId, pipelineId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.deletePipeline(programId, pipelineId)
   }
 }
 

--- a/src/commands/cloudmanager/pipeline/list-variables.js
+++ b/src/commands/cloudmanager/pipeline/list-variables.js
@@ -24,7 +24,7 @@ class ListPipelineVariablesCommand extends BasePipelineVariablesCommand {
     let result
 
     try {
-      result = await this.getVariables(programId, args, flags.passphrase)
+      result = await this.getVariables(programId, args, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/pipeline/set-variables.js
+++ b/src/commands/cloudmanager/pipeline/set-variables.js
@@ -12,19 +12,8 @@ governing permissions and limitations under the License.
 
 const BasePipelineVariablesCommand = require('../../../base-pipeline-variables-command')
 const BaseVariablesCommand = require('../../../base-variables-command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId } = require('../../../cloudmanager-helpers')
-const { init } = require('@adobe/aio-lib-cloudmanager')
+const { initSdk } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
-
-async function _setPipelineVariables (programId, pipelineId, variables, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.setPipelineVariables(programId, pipelineId, variables)
-}
 
 class SetPipelineVariablesCommand extends BasePipelineVariablesCommand {
   async run () {
@@ -33,8 +22,9 @@ class SetPipelineVariablesCommand extends BasePipelineVariablesCommand {
     return this.runSet(args, flags)
   }
 
-  async setVariables (programId, args, variables, passphrase = null) {
-    return _setPipelineVariables(programId, args.pipelineId, variables, passphrase)
+  async setVariables (programId, args, variables, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.setPipelineVariables(programId, args.pipelineId, variables)
   }
 }
 

--- a/src/commands/cloudmanager/pipeline/update.js
+++ b/src/commands/cloudmanager/pipeline/update.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command, flags } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _updatePipeline (programId, pipelineId, changes, passphrase) {
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.updatePipeline(programId, pipelineId, changes)
-}
 
 class UpdatePipelineCommand extends Command {
   async run () {
@@ -49,7 +38,7 @@ class UpdatePipelineCommand extends Command {
     cli.action.start('updating pipeline')
 
     try {
-      result = await this.updatePipeline(programId, args.pipelineId, flags, flags.passphrase)
+      result = await this.updatePipeline(programId, args.pipelineId, flags, flags.imsContextName)
       cli.action.stop(`updated pipeline ID ${args.pipelineId}`)
     } catch (error) {
       cli.action.stop(error.message)
@@ -59,8 +48,9 @@ class UpdatePipelineCommand extends Command {
     return result
   }
 
-  async updatePipeline (programId, pipelineId, changes, passphrase = null) {
-    return _updatePipeline(programId, pipelineId, changes, passphrase)
+  async updatePipeline (programId, pipelineId, changes, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.updatePipeline(programId, pipelineId, changes)
   }
 }
 

--- a/src/commands/cloudmanager/program/delete.js
+++ b/src/commands/cloudmanager/program/delete.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId } = require('../../../cloudmanager-helpers')
+const { initSdk } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _deleteProgram (programId, passphrase) {
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.deleteProgram(programId)
-}
 
 class DeleteProgramCommand extends Command {
   async run () {
@@ -35,7 +24,7 @@ class DeleteProgramCommand extends Command {
     cli.action.start('deleting program')
 
     try {
-      result = await this.deleteProgram(args.programId, flags.passphrase)
+      result = await this.deleteProgram(args.programId, flags.imsContextName)
       cli.action.stop(`deleted program ID ${args.programId}`)
     } catch (error) {
       cli.action.stop(error.message)
@@ -45,8 +34,9 @@ class DeleteProgramCommand extends Command {
     return result
   }
 
-  async deleteProgram (programId, passphrase = null) {
-    return _deleteProgram(programId, passphrase)
+  async deleteProgram (programId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.deleteProgram(programId)
   }
 }
 

--- a/src/commands/cloudmanager/program/list-environments.js
+++ b/src/commands/cloudmanager/program/list-environments.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _listEnvironments (programId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.listEnvironments(programId)
-}
 
 class ListEnvironmentsCommand extends Command {
   async run () {
@@ -35,7 +24,7 @@ class ListEnvironmentsCommand extends Command {
     let result
 
     try {
-      result = await this.listEnvironments(programId, flags.passphrase)
+      result = await this.listEnvironments(programId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -58,8 +47,9 @@ class ListEnvironmentsCommand extends Command {
     return result
   }
 
-  async listEnvironments (programId, passphrase = null) {
-    return _listEnvironments(programId, passphrase)
+  async listEnvironments (programId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.listEnvironments(programId)
   }
 }
 

--- a/src/commands/cloudmanager/program/list-ip-allowlists.js
+++ b/src/commands/cloudmanager/program/list-ip-allowlists.js
@@ -11,21 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat, columnWithArray } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, getOutputFormat, columnWithArray } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
 const ListEnvironmentsCommand = require('./list-environments')
-
-async function _listIpAllowlists (programId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.listIpAllowlists(programId)
-}
 
 class ListIPAllowlists extends Command {
   async run () {
@@ -36,14 +25,14 @@ class ListIPAllowlists extends Command {
     let result
 
     try {
-      result = await this.listIpAllowlists(programId, flags.passphrase)
+      result = await this.listIpAllowlists(programId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
 
     let environments
     try {
-      environments = await new ListEnvironmentsCommand().listEnvironments(programId, flags.passphrase)
+      environments = await new ListEnvironmentsCommand().listEnvironments(programId, flags.imsContextName)
     } catch (error) {
     }
 
@@ -90,8 +79,9 @@ class ListIPAllowlists extends Command {
     return result
   }
 
-  async listIpAllowlists (programId, passphrase = null) {
-    return _listIpAllowlists(programId, passphrase)
+  async listIpAllowlists (programId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.listIpAllowlists(programId)
   }
 }
 

--- a/src/commands/cloudmanager/program/list-pipelines.js
+++ b/src/commands/cloudmanager/program/list-pipelines.js
@@ -11,20 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command')
-const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, getOutputFormat } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
-const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../../common-flags')
-
-async function _listPipelines (programId, passphrase) {
-  const apiKey = await getApiKey()
-  const accessToken = await getAccessToken(passphrase)
-  const orgId = await getOrgId()
-  const baseUrl = await getBaseUrl()
-  const sdk = await init(orgId, apiKey, accessToken, baseUrl)
-  return sdk.listPipelines(programId)
-}
 
 class ListPipelinesCommand extends Command {
   async run () {
@@ -35,7 +24,7 @@ class ListPipelinesCommand extends Command {
     let result
 
     try {
-      result = await this.listPipelines(programId, flags.passphrase)
+      result = await this.listPipelines(programId, flags.imsContextName)
     } catch (error) {
       this.error(error.message)
     }
@@ -54,8 +43,9 @@ class ListPipelinesCommand extends Command {
     return result
   }
 
-  async listPipelines (programId, passphrase = null) {
-    return _listPipelines(programId, passphrase)
+  async listPipelines (programId, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.listPipelines(programId)
   }
 }
 

--- a/src/common-flags.js
+++ b/src/common-flags.js
@@ -13,7 +13,7 @@ const { flags } = require('@oclif/command')
 
 module.exports = {
   global: {
-    passphrase: flags.string({ char: 'r', description: 'the passphrase for the private key' }),
+    imsContextName: flags.string({ description: 'the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager' }),
   },
   programId: {
     programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" }),

--- a/src/hooks/init/migrate-jwt-context-hook.js
+++ b/src/hooks/init/migrate-jwt-context-hook.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const Config = require('@adobe/aio-lib-core-config')
+const loggerNamespace = '@adobe/aio-cli-plugin-cloudmanager:migrate-jwt-context-hook'
+const logger = require('@adobe/aio-lib-core-logging')(loggerNamespace, { level: process.env.LOG_LEVEL })
+const { defaultContextName } = require('../../cloudmanager-helpers')
+
+const oldConfigKey = 'jwt-auth'
+const newConfigKey = `ims.contexts.${defaultContextName}`
+
+function generateNewConfig (oldConfig) {
+  const newConfigData = {
+    client_id: oldConfig.client_id,
+    client_secret: oldConfig.client_secret,
+    technical_account_id: oldConfig.jwt_payload.sub,
+    technical_account_email: 'unused',
+    ims_org_id: oldConfig.jwt_payload.iss,
+    private_key: oldConfig.jwt_private_key,
+    meta_scopes: [],
+  }
+  Object.keys(oldConfig.jwt_payload)
+    .filter(key => key.startsWith('https://ims-na1.adobelogin.com/s/') && typeof oldConfig.jwt_payload[key] === 'boolean' && oldConfig.jwt_payload[key])
+    .forEach(key => newConfigData.meta_scopes.push(key.substring(33)))
+
+  return newConfigData
+}
+
+// if necessary, migrate the old configuration from the local store. return true if the local config has the new config key or false otherwise.
+function migrateLocal () {
+  const oldConfig = Config.get(oldConfigKey, 'local')
+  const newConfig = Config.get(newConfigKey, 'local')
+
+  if (newConfig) {
+    logger.debug('New IMS configuration detected in local. No need to migrate.')
+    return true
+  }
+
+  if (oldConfig && !newConfig) {
+    logger.debug(`Migrating local JWT configuration from '${oldConfigKey}' to '${newConfigKey}'.`)
+
+    const newConfigData = generateNewConfig(oldConfig)
+
+    Config.set(newConfigKey, newConfigData, true)
+    logger.debug(`Your JWT configuration has been migrated. The original configuration has been left in place. If it is no longer needed, you may remove it using 'aio config:delete --local ${oldConfigKey}'`)
+    return true
+  }
+
+  return false
+}
+function migrateGlobal () {
+  const oldConfig = Config.get(oldConfigKey, 'global')
+  const newConfig = Config.get(newConfigKey, 'global')
+
+  if (newConfig) {
+    logger.debug('New IMS configuration detected in global. No need to migrate.')
+    return true
+  }
+
+  if (oldConfig && !newConfig) {
+    logger.debug(`Migrating global JWT configuration from '${oldConfigKey}' to '${newConfigKey}'.`)
+
+    const newConfigData = generateNewConfig(oldConfig)
+
+    Config.set(newConfigKey, newConfigData, false)
+    logger.debug(`Your JWT configuration has been migrated. The original configuration has been left in place. If it is no longer needed, you may remove it using 'aio config:delete --global ${oldConfigKey}'`)
+    return true
+  }
+
+  return false
+}
+
+const migrate = async () => {
+  logger.debug('start jwt-auth migration hook')
+  if (!migrateLocal()) {
+    migrateGlobal()
+  }
+  logger.debug('end jwt-auth migration hook')
+}
+
+module.exports = migrate

--- a/test/__mocks__/@adobe/aio-lib-core-config.js
+++ b/test/__mocks__/@adobe/aio-lib-core-config.js
@@ -10,10 +10,20 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-let mockStore = {}
+const mockStores = {
+  general: {},
+  local: {},
+  global: {},
+}
 
 module.exports = {
-  get: jest.fn(k => mockStore[k]),
-  setStore: (s) => (mockStore = s),
+  get: jest.fn((k, scope) => {
+    scope = scope || 'general'
+    return mockStores[scope][k]
+  }),
+  setStore: (s) => (mockStores.general = s),
+  setGlobalStore: (s) => (mockStores.global = s),
+  setLocalStore: (s) => (mockStores.local = s),
   getPipedData: jest.fn(),
+  set: jest.fn(),
 }

--- a/test/__mocks__/@adobe/aio-lib-ims.js
+++ b/test/__mocks__/@adobe/aio-lib-ims.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Adobe. All rights reserved.
+Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,8 +10,32 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+let currentOrgId
+
 module.exports = {
-  accessToken: () => {
-    return Promise.resolve('fake-token')
+  getToken: jest.fn(ctx => 'fake-token'),
+  context: {
+    setCurrent: jest.fn(),
+    get: jest.fn(() => {
+      if (currentOrgId) {
+        return {
+          data: {
+            client_id: 'test-client-id',
+            ims_org_id: currentOrgId,
+          },
+        }
+      } else {
+        return {
+          data: undefined,
+        }
+      }
+    }),
+    set: jest.fn(),
+  },
+  setCurrentOrgId: (o) => {
+    currentOrgId = o
+  },
+  resetCurrentOrgId: () => {
+    currentOrgId = undefined
   },
 }

--- a/test/commands/current-execution/advance.test.js
+++ b/test/commands/current-execution/advance.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const AdvanceCurrentExecution = require('../../../src/commands/cloudmanager/current-execution/advance')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId({})
 })
 
 test('advance-current-execution - missing arg', async () => {
@@ -33,18 +33,11 @@ test('advance-current-execution - missing config', async () => {
   const runResult = AdvanceCurrentExecution.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toEqual(undefined)
-  await expect(cli.action.stop.mock.calls[0][0]).toBe('missing config data: jwt-auth')
+  await expect(cli.action.stop.mock.calls[0][0]).toBe('Unable to find IMS context aio-cli-plugin-cloudmanager')
 })
 
 test('advance-current-execution - configured', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -52,7 +45,7 @@ test('advance-current-execution - configured', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.advanceCurrentExecution.mock.calls.length).toEqual(1)
   await expect(mockSdk.advanceCurrentExecution).toHaveBeenCalledWith('5', '10')
 })

--- a/test/commands/current-execution/cancel.test.js
+++ b/test/commands/current-execution/cancel.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const CancelCurrentExecution = require('../../../src/commands/cloudmanager/current-execution/cancel')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId({})
 })
 
 test('cancel-current-execution - missing arg', async () => {
@@ -33,18 +33,11 @@ test('cancel-current-execution - missing config', async () => {
   const runResult = CancelCurrentExecution.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toEqual(undefined)
-  await expect(cli.action.stop.mock.calls[0][0]).toBe('missing config data: jwt-auth')
+  await expect(cli.action.stop.mock.calls[0][0]).toBe('Unable to find IMS context aio-cli-plugin-cloudmanager')
 })
 
 test('cancel-current-execution - configured', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -52,7 +45,7 @@ test('cancel-current-execution - configured', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.cancelCurrentExecution.mock.calls.length).toEqual(1)
   await expect(mockSdk.cancelCurrentExecution).toHaveBeenCalledWith('5', '10')
 })

--- a/test/commands/current-execution/get.test.js
+++ b/test/commands/current-execution/get.test.js
@@ -11,13 +11,13 @@ governing permissions and limitations under the License.
 */
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const GetCurrentExecution = require('../../../src/commands/cloudmanager/current-execution/get')
 const execution1010 = require('../../data/execution1010.json')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('get-current-execution - missing arg', async () => {
@@ -33,18 +33,11 @@ test('get-current-execution - missing config', async () => {
 
   const runResult = GetCurrentExecution.run(['5', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('get-current-execution - configured', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(7)
 
@@ -52,7 +45,7 @@ test('get-current-execution - configured', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getCurrentExecution.mock.calls.length).toEqual(1)
   await expect(mockSdk.getCurrentExecution).toHaveBeenCalledWith('5', '5')
 

--- a/test/commands/environment/bind-ip-allowlist.test.js
+++ b/test/commands/environment/bind-ip-allowlist.test.js
@@ -13,20 +13,13 @@ governing permissions and limitations under the License.
 const BindIpAllowlist = require('../../../src/commands/cloudmanager/environment/bind-ip-allowlist')
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/environment/delete.test.js
+++ b/test/commands/environment/delete.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const DeleteEnvironmentCommand = require('../../../src/commands/cloudmanager/environment/delete')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('delete-environment - missing arg', async () => {
@@ -33,18 +33,11 @@ test('delete-environment - missing config', async () => {
   const runResult = DeleteEnvironmentCommand.run(['--programId', '4', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toEqual(undefined)
-  await expect(cli.action.stop.mock.calls[0][0]).toBe('missing config data: jwt-auth')
+  await expect(cli.action.stop.mock.calls[0][0]).toBe('Unable to find IMS context aio-cli-plugin-cloudmanager')
 })
 
 test('delete-environment - configured', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -52,7 +45,7 @@ test('delete-environment - configured', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.deleteEnvironment.mock.calls.length).toEqual(1)
   await expect(mockSdk.deleteEnvironment).toHaveBeenCalledWith('4', '3')
 })

--- a/test/commands/environment/list-available-log-options.test.js
+++ b/test/commands/environment/list-available-log-options.test.js
@@ -13,10 +13,11 @@ governing permissions and limitations under the License.
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const ListAvailableLogOptionsCommand = require('../../../src/commands/cloudmanager/environment/list-available-log-options')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('list-available-logs - missing arg', async () => {
@@ -40,17 +41,12 @@ test('list-available-logs - missing config', async () => {
 
   const runResult = ListAvailableLogOptionsCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('list-available-logs - empty', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '6',
   })
 
@@ -60,20 +56,15 @@ test('list-available-logs - empty', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.listAvailableLogOptions.mock.calls.length).toEqual(1)
   await expect(mockSdk.listAvailableLogOptions).toHaveBeenCalledWith('6', '1')
   await expect(cli.info.mock.calls[0][0]).toBe('No log options are available for environmentId 1')
 })
 
 test('list-available-logs - some entries', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '6',
   })
   mockSdk.listAvailableLogOptions = jest.fn(() => [
@@ -121,7 +112,7 @@ test('list-available-logs - some entries', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.listAvailableLogOptions.mock.calls.length).toEqual(1)
   await expect(mockSdk.listAvailableLogOptions).toHaveBeenCalledWith('6', '42')
   await expect(cli.info.mock.calls).toHaveLength(0)

--- a/test/commands/environment/list-ip-allowlist-bindings.test.js
+++ b/test/commands/environment/list-ip-allowlist-bindings.test.js
@@ -10,21 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 const ListIPAllowlistBindings = require('../../../src/commands/cloudmanager/environment/list-ip-allowlist-bindings')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/environment/open-developer-console.test.js
+++ b/test/commands/environment/open-developer-console.test.js
@@ -12,11 +12,12 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { setStore } = require('@adobe/aio-lib-core-config')
 const OpenDeveloperConsoleCommand = require('../../../src/commands/cloudmanager/environment/open-developer-console')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('open-developer-console - missing arg', async () => {
@@ -40,17 +41,12 @@ test('open-developer-console - missing config', async () => {
 
   const runResult = OpenDeveloperConsoleCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('open-developer-console - success', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -60,7 +56,7 @@ test('open-developer-console - success', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getDeveloperConsoleUrl.mock.calls.length).toEqual(1)
   await expect(mockSdk.getDeveloperConsoleUrl).toHaveBeenCalledWith('4', '1')
   await expect(cli.open.mock.calls[0][0]).toBe('https://github.com/adobe/aio-cli-plugin-cloudmanager')

--- a/test/commands/environment/set-variables.test.js
+++ b/test/commands/environment/set-variables.test.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 const fs = require('fs')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { setStore, getPipedData } = require('@adobe/aio-lib-core-config')
 const SetEnvironmentVariablesCommand = require('../../../src/commands/cloudmanager/environment/set-variables')
 
@@ -33,7 +34,7 @@ fs.readFile = jest.fn((fileName, encoding, callback) => {
 })
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('set-environment-variables - missing arg', async () => {
@@ -57,17 +58,12 @@ test('set-environment-variables - missing config', async () => {
 
   const runResult = SetEnvironmentVariablesCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('set-environment-variables - bad variable flag', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -79,13 +75,8 @@ test('set-environment-variables - bad variable flag', async () => {
 })
 
 test('set-environment-variables - bad secret flag', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -97,13 +88,8 @@ test('set-environment-variables - bad secret flag', async () => {
 })
 
 test('set-environment-variables - config', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '6',
   })
 
@@ -114,18 +100,13 @@ test('set-environment-variables - config', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(2)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(0)
 })
 
 test('set-environment-variables - variables only', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -136,7 +117,7 @@ test('set-environment-variables - variables only', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -150,13 +131,8 @@ test('set-environment-variables - variables only', async () => {
 })
 
 test('set-environment-variables - secrets only', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -167,7 +143,7 @@ test('set-environment-variables - secrets only', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -181,13 +157,8 @@ test('set-environment-variables - secrets only', async () => {
 })
 
 test('set-environment-variables - secret and variable', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -198,7 +169,7 @@ test('set-environment-variables - secret and variable', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -212,13 +183,8 @@ test('set-environment-variables - secret and variable', async () => {
 })
 
 test('set-environment-variables - delete', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -229,7 +195,7 @@ test('set-environment-variables - delete', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'KEY',
@@ -239,13 +205,8 @@ test('set-environment-variables - delete', async () => {
 })
 
 test('set-environment-variables - delete secret', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -256,7 +217,7 @@ test('set-environment-variables - delete secret', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'I_AM_A_SECRET',
@@ -266,13 +227,8 @@ test('set-environment-variables - delete secret', async () => {
 })
 
 test('set-environment-variables - delete not found', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -283,18 +239,13 @@ test('set-environment-variables - delete not found', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(2)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(0)
 })
 
 test('set-environment-variables - stdin - not JSON', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -309,13 +260,8 @@ test('set-environment-variables - stdin - not JSON', async () => {
 })
 
 test('set-environment-variables - file - not JSON', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -330,13 +276,8 @@ test('set-environment-variables - file - not JSON', async () => {
 })
 
 test('set-environment-variables - stdin - not array', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -351,13 +292,8 @@ test('set-environment-variables - stdin - not array', async () => {
 })
 
 test('set-environment-variables - stdin - secret and variable', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -381,7 +317,7 @@ test('set-environment-variables - stdin - secret and variable', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -395,13 +331,8 @@ test('set-environment-variables - stdin - secret and variable', async () => {
 })
 
 test('set-environment-variables - file - secret and variable', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -425,7 +356,7 @@ test('set-environment-variables - file - secret and variable', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -439,13 +370,8 @@ test('set-environment-variables - file - secret and variable', async () => {
 })
 
 test('set-environment-variables - stdin - variable in flag overrides stdin', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -464,7 +390,7 @@ test('set-environment-variables - stdin - variable in flag overrides stdin', asy
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -474,13 +400,8 @@ test('set-environment-variables - stdin - variable in flag overrides stdin', asy
 })
 
 test('set-environment-variables - stdin - delete from stream', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -499,7 +420,7 @@ test('set-environment-variables - stdin - delete from stream', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'I_AM_A_SECRET',
@@ -509,13 +430,8 @@ test('set-environment-variables - stdin - delete from stream', async () => {
 })
 
 test('set-environment-variables - stdin - missing name', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -533,18 +449,13 @@ test('set-environment-variables - stdin - missing name', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(2)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(0)
 })
 
 test('set-environment-variables - both jsonStdin and jsonFile', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
   expect.assertions(2)

--- a/test/commands/environment/tail-log.test.js
+++ b/test/commands/environment/tail-log.test.js
@@ -10,12 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const TailLog = require('../../../src/commands/cloudmanager/environment/tail-log')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('tail-log - missing arg', async () => {
@@ -31,18 +31,11 @@ test('tail-log - missing config', async () => {
 
   const runResult = TailLog.run(['5', 'author', 'aemerror', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('tail-log - config', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -50,7 +43,7 @@ test('tail-log - config', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.tailLog.mock.calls.length).toEqual(1)
   await expect(mockSdk.tailLog).toHaveBeenCalledWith('5', '17', 'author', 'aemerror', process.stdout)
 })

--- a/test/commands/environment/unbind-ip-allowlist.test.js
+++ b/test/commands/environment/unbind-ip-allowlist.test.js
@@ -13,20 +13,13 @@ governing permissions and limitations under the License.
 const UnunbindIpAllowlist = require('../../../src/commands/cloudmanager/environment/unbind-ip-allowlist')
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/execution/get-quality-gate-results.test.js
+++ b/test/commands/execution/get-quality-gate-results.test.js
@@ -12,13 +12,13 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, generateNewMock } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const GetQualityGateResults = require('../../../src/commands/cloudmanager/execution/get-quality-gate-results')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
   mockSdk = generateNewMock()
 })
 
@@ -35,18 +35,11 @@ test('get-quality-gate-results - missing config', async () => {
 
   const runResult = GetQualityGateResults.run(['5', '--programId', '7', '1001', 'codeQuality'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('get-quality-gate-results - happy path', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(6)
 
@@ -55,7 +48,7 @@ test('get-quality-gate-results - happy path', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getQualityGateResults.mock.calls.length).toEqual(1)
   await expect(mockSdk.getQualityGateResults).toHaveBeenCalledWith('15', '5', '1002', 'codeQuality')
 
@@ -63,14 +56,7 @@ test('get-quality-gate-results - happy path', async () => {
 })
 
 test('get-quality-gate-results - no metrics', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk.getQualityGateResults = jest.fn(() => Promise.resolve({}))
 
   expect.assertions(6)
@@ -79,20 +65,13 @@ test('get-quality-gate-results - no metrics', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Metrics for action codeQuality on execution 1002 could not be found.'))
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getQualityGateResults.mock.calls.length).toEqual(1)
   await expect(mockSdk.getQualityGateResults).toHaveBeenCalledWith('15', '5', '1002', 'codeQuality')
 })
 
 test('get-quality-gate-results - experienceAudit', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(11)
 
@@ -101,7 +80,7 @@ test('get-quality-gate-results - experienceAudit', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getQualityGateResults.mock.calls.length).toEqual(1)
   await expect(mockSdk.getQualityGateResults).toHaveBeenCalledWith('15', '5', '1002', 'contentAudit')
 

--- a/test/commands/execution/get-step-log.test.js
+++ b/test/commands/execution/get-step-log.test.js
@@ -12,12 +12,12 @@ governing permissions and limitations under the License.
 
 const tmp = require('tmp')
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const GetExecutionStepLog = require('../../../src/commands/cloudmanager/execution/get-step-log')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('get-execution-step-log - missing arg', async () => {
@@ -33,18 +33,11 @@ test('get-execution-step-log - missing config', async () => {
 
   const runResult = GetExecutionStepLog.run(['5', '--programId', '7', '1001', 'codeQuality'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('get-execution-step-log - stdout', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -53,20 +46,13 @@ test('get-execution-step-log - stdout', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getExecutionStepLog.mock.calls.length).toEqual(1)
   await expect(mockSdk.getExecutionStepLog).toHaveBeenCalledWith('5', '15', '1002', 'codeQuality', undefined, process.stdout)
 })
 
 test('get-execution-step-log - success alternate file', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -75,7 +61,7 @@ test('get-execution-step-log - success alternate file', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getExecutionStepLog.mock.calls.length).toEqual(1)
   await expect(mockSdk.getExecutionStepLog).toHaveBeenCalledWith('5', '7', '1001', 'codeQuality', 'somethingspecial', process.stdout)
 })
@@ -83,14 +69,7 @@ test('get-execution-step-log - success alternate file', async () => {
 test('get-execution-step-log - file', async () => {
   const tmpFile = tmp.fileSync()
 
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(11)
 
@@ -99,7 +78,7 @@ test('get-execution-step-log - file', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.getExecutionStepLog.mock.calls.length).toEqual(1)
   await expect(mockSdk.getExecutionStepLog.mock.calls[0][0]).toEqual('5')
   await expect(mockSdk.getExecutionStepLog.mock.calls[0][1]).toEqual('15')

--- a/test/commands/ip-allowlist/bind.test.js
+++ b/test/commands/ip-allowlist/bind.test.js
@@ -13,20 +13,13 @@ governing permissions and limitations under the License.
 const BindIpAllowlist = require('../../../src/commands/cloudmanager/ip-allowlist/bind')
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/ip-allowlist/create.test.js
+++ b/test/commands/ip-allowlist/create.test.js
@@ -13,20 +13,13 @@ governing permissions and limitations under the License.
 const CreateIpAllowlist = require('../../../src/commands/cloudmanager/ip-allowlist/create')
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/ip-allowlist/delete.test.js
+++ b/test/commands/ip-allowlist/delete.test.js
@@ -12,20 +12,13 @@ governing permissions and limitations under the License.
 
 const DeleteIpAllowlist = require('../../../src/commands/cloudmanager/ip-allowlist/delete')
 
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/ip-allowlist/get-binding-details.test.js
+++ b/test/commands/ip-allowlist/get-binding-details.test.js
@@ -11,21 +11,14 @@ governing permissions and limitations under the License.
 */
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 const ListIPAllowlistBindingDetails = require('../../../src/commands/cloudmanager/ip-allowlist/get-binding-details')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/ip-allowlist/unbind.test.js
+++ b/test/commands/ip-allowlist/unbind.test.js
@@ -13,20 +13,13 @@ governing permissions and limitations under the License.
 const UnunbindIpAllowlist = require('../../../src/commands/cloudmanager/ip-allowlist/unbind')
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/ip-allowlist/update.test.js
+++ b/test/commands/ip-allowlist/update.test.js
@@ -12,20 +12,13 @@ governing permissions and limitations under the License.
 
 const UpdateIpAllowlist = require('../../../src/commands/cloudmanager/ip-allowlist/update')
 
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/commands/list-programs.test.js
+++ b/test/commands/list-programs.test.js
@@ -10,12 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const ListProgramsCommand = require('../../src/commands/cloudmanager/list-programs')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('list-programs - missing config', async () => {
@@ -23,44 +23,30 @@ test('list-programs - missing config', async () => {
 
   const runResult = ListProgramsCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
   expect(init.mock.calls.length).toEqual(0)
 })
 
 test('list-programs - args', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   expect.assertions(5)
 
   const runResult = ListProgramsCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toHaveLength(2)
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.listPrograms.mock.calls.length).toEqual(1)
 })
 
 test('list-programs - enabled only', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   expect.assertions(5)
 
   const runResult = ListProgramsCommand.run(['--enabledonly'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toHaveLength(1)
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.listPrograms.mock.calls.length).toEqual(1)
 })

--- a/test/commands/pipeline/create-execution.test.js
+++ b/test/commands/pipeline/create-execution.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const StartExecutionCommand = require('../../../src/commands/cloudmanager/pipeline/create-execution')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('start-execution - missing arg', async () => {
@@ -33,18 +33,11 @@ test('start-execution - missing config', async () => {
   const runResult = StartExecutionCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toEqual(undefined)
-  await expect(cli.action.stop.mock.calls[0][0]).toBe('missing config data: jwt-auth')
+  await expect(cli.action.stop.mock.calls[0][0]).toBe('Unable to find IMS context aio-cli-plugin-cloudmanager')
 })
 
 test('start-execution - some url', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk.createExecution = jest.fn(() => Promise.resolve({
     id: '5000',
   }))
@@ -55,7 +48,7 @@ test('start-execution - some url', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.createExecution.mock.calls.length).toEqual(1)
   await expect(mockSdk.createExecution).toHaveBeenCalledWith('5', '10')
 

--- a/test/commands/pipeline/delete.test.js
+++ b/test/commands/pipeline/delete.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const DeletePipelineCommand = require('../../../src/commands/cloudmanager/pipeline/delete')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('delete-pipeline - missing arg', async () => {
@@ -33,18 +33,11 @@ test('delete-pipeline - missing config', async () => {
   const runResult = DeletePipelineCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toEqual(undefined)
-  await expect(cli.action.stop.mock.calls[0][0]).toBe('missing config data: jwt-auth')
+  await expect(cli.action.stop.mock.calls[0][0]).toBe('Unable to find IMS context aio-cli-plugin-cloudmanager')
 })
 
 test('delete-pipeline - configured', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -52,7 +45,7 @@ test('delete-pipeline - configured', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.deletePipeline.mock.calls.length).toEqual(1)
   await expect(mockSdk.deletePipeline).toHaveBeenCalledWith('5', '7')
 })

--- a/test/commands/pipeline/set-variables.test.js
+++ b/test/commands/pipeline/set-variables.test.js
@@ -11,11 +11,12 @@ governing permissions and limitations under the License.
 */
 
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { setStore } = require('@adobe/aio-lib-core-config')
 const SetPipelineVariablesCommand = require('../../../src/commands/cloudmanager/pipeline/set-variables')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('set-pipeline-variables - missing arg', async () => {
@@ -39,17 +40,12 @@ test('set-pipeline-variables - missing config', async () => {
 
   const runResult = SetPipelineVariablesCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('set-pipeline-variables - bad variable flag', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '5',
   })
 
@@ -61,13 +57,8 @@ test('set-pipeline-variables - bad variable flag', async () => {
 })
 
 test('set-pipeline-variables - bad secret flag', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '5',
   })
 
@@ -78,13 +69,8 @@ test('set-pipeline-variables - bad secret flag', async () => {
   await expect(runResult).rejects.toEqual(new Error('Please provide correct values for flags'))
 })
 test('set-pipeline-variables - config', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '6',
   })
 
@@ -95,18 +81,13 @@ test('set-pipeline-variables - config', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(2)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setPipelineVariables.mock.calls.length).toEqual(0)
 })
 
 test('set-pipeline-variables - variables only', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -117,7 +98,7 @@ test('set-pipeline-variables - variables only', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setPipelineVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setPipelineVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -131,13 +112,8 @@ test('set-pipeline-variables - variables only', async () => {
 })
 
 test('set-pipeline-variables - secrets only', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -148,7 +124,7 @@ test('set-pipeline-variables - secrets only', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setPipelineVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setPipelineVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -162,13 +138,8 @@ test('set-pipeline-variables - secrets only', async () => {
 })
 
 test('set-pipeline-variables - secret and variable', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -179,7 +150,7 @@ test('set-pipeline-variables - secret and variable', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setPipelineVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setPipelineVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'foo',
@@ -193,13 +164,8 @@ test('set-pipeline-variables - secret and variable', async () => {
 })
 
 test('set-pipeline-variables - delete', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -210,7 +176,7 @@ test('set-pipeline-variables - delete', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setPipelineVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setPipelineVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'KEY',
@@ -220,13 +186,8 @@ test('set-pipeline-variables - delete', async () => {
 })
 
 test('set-pipeline-variables - delete secret', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -237,7 +198,7 @@ test('set-pipeline-variables - delete secret', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(3)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setPipelineVariables.mock.calls.length).toEqual(1)
   await expect(mockSdk.setPipelineVariables).toHaveBeenCalledWith('4', '1', [{
     name: 'I_AM_A_SECRET',
@@ -247,13 +208,8 @@ test('set-pipeline-variables - delete secret', async () => {
 })
 
 test('set-pipeline-variables - delete not found', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 
@@ -264,18 +220,13 @@ test('set-pipeline-variables - delete not found', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(2)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.setPipelineVariables.mock.calls.length).toEqual(0)
 })
 
 test('set-pipeline-variables - second get fails', async () => {
+  setCurrentOrgId('good')
   setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
     cloudmanager_programid: '4',
   })
 

--- a/test/commands/pipeline/update.test.js
+++ b/test/commands/pipeline/update.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const UpdatePipelineCommand = require('../../../src/commands/cloudmanager/pipeline/update')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('update-pipeline - missing arg', async () => {
@@ -33,18 +33,11 @@ test('update-pipeline - missing config', async () => {
   const runResult = UpdatePipelineCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toEqual(undefined)
-  await expect(cli.action.stop.mock.calls[0][0]).toBe('missing config data: jwt-auth')
+  await expect(cli.action.stop.mock.calls[0][0]).toBe('Unable to find IMS context aio-cli-plugin-cloudmanager')
 })
 
 test('update-pipeline - branch success', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(8)
 
@@ -53,7 +46,7 @@ test('update-pipeline - branch success', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.updatePipeline.mock.calls.length).toEqual(1)
   await expect(mockSdk.updatePipeline.mock.calls[0][0]).toEqual('5')
   await expect(mockSdk.updatePipeline.mock.calls[0][1]).toEqual('10')
@@ -64,14 +57,7 @@ test('update-pipeline - branch success', async () => {
 })
 
 test('update-pipeline - repository and branch success', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(8)
 
@@ -80,7 +66,7 @@ test('update-pipeline - repository and branch success', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.updatePipeline.mock.calls.length).toEqual(1)
   await expect(mockSdk.updatePipeline.mock.calls[0][0]).toEqual('5')
   await expect(mockSdk.updatePipeline.mock.calls[0][1]).toEqual('10')
@@ -92,14 +78,7 @@ test('update-pipeline - repository and branch success', async () => {
 })
 
 test('update-pipeline - both tag and branch', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(2)
 
@@ -109,14 +88,7 @@ test('update-pipeline - both tag and branch', async () => {
 })
 
 test('update-pipeline - malformed tag', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(2)
 
@@ -126,14 +98,7 @@ test('update-pipeline - malformed tag', async () => {
 })
 
 test('update-pipeline - correct tag', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(8)
 
@@ -142,7 +107,7 @@ test('update-pipeline - correct tag', async () => {
 
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.updatePipeline.mock.calls.length).toEqual(1)
   await expect(mockSdk.updatePipeline.mock.calls[0][0]).toEqual('5')
   await expect(mockSdk.updatePipeline.mock.calls[0][1]).toEqual('10')

--- a/test/commands/program/delete.test.js
+++ b/test/commands/program/delete.test.js
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const DeleteProgramCommand = require('../../../src/commands/cloudmanager/program/delete')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('delete-program - missing arg', async () => {
@@ -33,18 +33,11 @@ test('delete-program - missing config', async () => {
   const runResult = DeleteProgramCommand.run(['5'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.toEqual(undefined)
-  await expect(cli.action.stop.mock.calls[0][0]).toBe('missing config data: jwt-auth')
+  await expect(cli.action.stop.mock.calls[0][0]).toBe('Unable to find IMS context aio-cli-plugin-cloudmanager')
 })
 
 test('delete-program - configured', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(5)
 
@@ -52,7 +45,7 @@ test('delete-program - configured', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.deleteProgram.mock.calls.length).toEqual(1)
   await expect(mockSdk.deleteProgram).toHaveBeenCalledWith('5')
 })

--- a/test/commands/program/list-current-executions.test.js
+++ b/test/commands/program/list-current-executions.test.js
@@ -11,11 +11,11 @@ governing permissions and limitations under the License.
 */
 
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const ListCurrentExecutions = require('../../../src/commands/cloudmanager/program/list-current-executions')
 
 beforeEach(() => {
-  setStore({})
+  resetCurrentOrgId()
 })
 
 test('list-current-executions - missing arg', async () => {
@@ -31,18 +31,11 @@ test('list-current-executions - missing config', async () => {
 
   const runResult = ListCurrentExecutions.run(['--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toEqual(new Error('missing config data: jwt-auth'))
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
 })
 
 test('list-current-executions - success', async () => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
 
   expect.assertions(7)
 
@@ -50,7 +43,7 @@ test('list-current-executions - success', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
-  await expect(init).toHaveBeenCalledWith('good', '1234', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.listPipelines.mock.calls.length).toEqual(1)
   await expect(mockSdk.listPipelines).toHaveBeenCalledWith('5', { busy: true })
   await expect(mockSdk.getCurrentExecution.mock.calls.length).toEqual(1)

--- a/test/commands/program/list-ip-allowlists.test.js
+++ b/test/commands/program/list-ip-allowlists.test.js
@@ -11,21 +11,14 @@ governing permissions and limitations under the License.
 */
 
 const { cli } = require('cli-ux')
-const { setStore } = require('@adobe/aio-lib-core-config')
+const { setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const { generateNewMock } = require('@adobe/aio-lib-cloudmanager')
 const ListIPAllowlists = require('../../../src/commands/cloudmanager/program/list-ip-allowlists')
 
 let mockSdk
 
 beforeEach(() => {
-  setStore({
-    'jwt-auth': JSON.stringify({
-      client_id: '1234',
-      jwt_payload: {
-        iss: 'good',
-      },
-    }),
-  })
+  setCurrentOrgId('good')
   mockSdk = generateNewMock()
 })
 

--- a/test/hooks/init/migrate-jwt-context-hook.test.js
+++ b/test/hooks/init/migrate-jwt-context-hook.test.js
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { setLocalStore, setGlobalStore, set } = require('@adobe/aio-lib-core-config')
+const migrate = require('../../../src/hooks/init/migrate-jwt-context-hook')
+
+const oldConfig = {
+  client_id: 'test-client-id',
+  client_secret: '5678',
+  jwt_payload: {
+    iss: 'someorg@AdobeOrg',
+    sub: '4321@techacct.adobe.com',
+    'https://ims-na1.adobelogin.com/s/ent_adobeio_sdk': true,
+    'https://ims-na1.adobelogin.com/s/ent_cloudmgr_sdk': true,
+    aud: 'https://ims-na1.adobelogin.com/c/4bc4f99554834477a0de0244d46a575f',
+  },
+  jwt_private_key: '-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n',
+}
+
+const newConfig = {
+  client_id: 'test-client-id',
+  client_secret: '5678',
+  ims_org_id: 'someorg@AdobeOrg',
+  technical_account_id: '4321@techacct.adobe.com',
+  technical_account_email: 'unused',
+  meta_scopes: [
+    'ent_adobeio_sdk',
+    'ent_cloudmgr_sdk',
+  ],
+  private_key: '-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n',
+}
+
+beforeEach(() => {
+  setLocalStore({})
+  setGlobalStore({})
+})
+
+test('migrate -- no existing jwt', async () => {
+  const runResult = migrate()
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(set.mock.calls.length).toBe(0)
+})
+
+test('migrate -- existing jwt and existing CM context in local only', async () => {
+  setLocalStore({
+    'jwt-auth': {},
+    'ims.contexts.aio-cli-plugin-cloudmanager': {},
+  })
+  const result = migrate()
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toEqual(undefined)
+  await expect(set.mock.calls.length).toBe(0)
+})
+
+test('migrate -- existing jwt and existing CM context in global only', async () => {
+  setGlobalStore({
+    'jwt-auth': {},
+    'ims.contexts.aio-cli-plugin-cloudmanager': {},
+  })
+  const result = migrate()
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toEqual(undefined)
+  await expect(set.mock.calls.length).toBe(0)
+})
+
+test('migrate -- existing jwt in local and no existing CM context', async () => {
+  setLocalStore({
+    'jwt-auth': oldConfig,
+    'ims.contexts.something-else': {},
+  })
+  const result = migrate()
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toEqual(undefined)
+  await expect(set.mock.calls.length).toBe(1)
+  await expect(set.mock.calls[0][0]).toEqual('ims.contexts.aio-cli-plugin-cloudmanager')
+  await expect(set.mock.calls[0][1]).toEqual(newConfig)
+  await expect(set.mock.calls[0][2]).toEqual(true)
+})
+
+test('migrate -- existing jwt in global and no existing CM context', async () => {
+  setGlobalStore({
+    'jwt-auth': oldConfig,
+    'ims.contexts.something-else': {},
+  })
+  const result = migrate()
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toEqual(undefined)
+  await expect(set.mock.calls.length).toBe(1)
+  await expect(set.mock.calls[0][0]).toEqual('ims.contexts.aio-cli-plugin-cloudmanager')
+  await expect(set.mock.calls[0][1]).toEqual(newConfig)
+  await expect(set.mock.calls[0][2]).toEqual(false)
+})
+
+test('migrate -- existing context in local and jwt in global (no-op)', async () => {
+  setLocalStore({
+    'ims.contexts.aio-cli-plugin-cloudmanager': newConfig,
+  })
+  setGlobalStore({
+    'jwt-auth': oldConfig,
+  })
+  const result = migrate()
+  await expect(result instanceof Promise).toBeTruthy()
+  await expect(result).resolves.toEqual(undefined)
+  await expect(set.mock.calls.length).toBe(0)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This replaces the deprecated @adobe/aio-cli-plugin-jwt-auth with @adobe/aio-lib-ims.

This is a breaking change because of the lack of passphrase support in @adobe/aio-lib-ims. All other configurations should be migrated successfully.

## Related Issue

#129 

## Motivation and Context

Deprecation of dependency

## How Has This Been Tested?

* unit tests
* manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
