### PR TITLE
Allow to use 'e'-prefixed env ids as found in cloud manager URLs

### DIFF
--- a/src/base-environment-variables-command.js
+++ b/src/base-environment-variables-command.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId } = require('./cloudmanager-helpers')
+const { getApiKey, getOrgId, sanitizeEnvironmentId } = require('./cloudmanager-helpers')
 const BaseVariablesCommand = require('./base-variables-command')
 const Client = require('./client')
 
@@ -25,7 +25,7 @@ async function _getEnvironmentVariables(programId, environmentId, passphrase) {
 class BaseEnvironmentVariablesCommand extends BaseVariablesCommand {
 
     async getVariables(programId, args, passphrase = null) {
-        return _getEnvironmentVariables(programId, args.environmentId, passphrase)
+        return _getEnvironmentVariables(programId, sanitizeEnvironmentId(args.environmentId), passphrase)
     }
 }
 

--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -108,6 +108,13 @@ function createKeyValueObjectFromFlag (flag) {
     }
   }
 
+function sanitizeEnvironmentId(environmentId) {
+    let envId = environmentId;
+    if(envId && envId.startsWith('e')) {
+        envId = envId.substring(1);
+    }
+    return envId
+}
 
 module.exports = {
     getBaseUrl,
@@ -118,5 +125,6 @@ module.exports = {
     getWaitingStep,
     isWithinFiveMinutesOfUTCMidnight,
     sleep,
-    createKeyValueObjectFromFlag
+    createKeyValueObjectFromFlag,
+    sanitizeEnvironmentId
 }

--- a/src/commands/cloudmanager/delete-environment.js
+++ b/src/commands/cloudmanager/delete-environment.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const Client = require('../../client')
 const commonFlags = require('../../common-flags')
@@ -34,9 +34,10 @@ class DeleteEnvironmentCommand extends Command {
 
     cli.action.start("deleting environment")
 
+    let envId = sanitizeEnvironmentId(args.environmentId);
     try {
-      result = await this.deleteEnvironment(programId, args.environmentId, flags.passphrase)
-      cli.action.stop(`deleted environment ID ${args.environmentId}`)
+      result = await this.deleteEnvironment(programId, envId, flags.passphrase)
+      cli.action.stop(`deleted environment ID ${envId}`)
     } catch (error) {
       cli.action.stop(error.message)
       return

--- a/src/commands/cloudmanager/download-logs.js
+++ b/src/commands/cloudmanager/download-logs.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command, flags } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const path = require('path')
 const Client = require('../../client')
@@ -38,7 +38,7 @@ class DownloadLogs extends Command {
         let result
 
         try {
-            result = await this.downloadLogs(programId, args.environmentId, args.service, args.name, args.days, outputDirectory, flags.passphrase)
+            result = await this.downloadLogs(programId, sanitizeEnvironmentId(args.environmentId), args.service, args.name, args.days, outputDirectory, flags.passphrase)
         } catch (error) {
             this.error(error.message)
         }

--- a/src/commands/cloudmanager/list-available-log-options.js
+++ b/src/commands/cloudmanager/list-available-log-options.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const Client = require('../../client')
 const commonFlags = require('../../common-flags')
@@ -32,8 +32,9 @@ class ListAvailableLogOptionsCommand extends Command {
 
         let result
 
+        let envId = sanitizeEnvironmentId(args.environmentId);
         try {
-            result = await this.listAvailableLogOptions(programId, args.environmentId, flags.passphrase)
+            result = await this.listAvailableLogOptions(programId, envId, flags.passphrase)
         } catch (error) {
             this.error(error.message)
         }
@@ -42,7 +43,7 @@ class ListAvailableLogOptionsCommand extends Command {
             cli.table(result, {
                 id: {
                     header: "Environment Id",
-                    get: () => args.environmentId
+                    get: () => envId
                 },
                 service: {},
                 name: {}
@@ -50,7 +51,7 @@ class ListAvailableLogOptionsCommand extends Command {
                     printLine: this.log
                 })
         } else {
-            cli.info(`No log options are available for environmentId ${args.environmentId}`)
+            cli.info(`No log options are available for environmentId ${envId}`)
         }
 
         return result

--- a/src/commands/cloudmanager/open-developer-console.js
+++ b/src/commands/cloudmanager/open-developer-console.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const Client = require('../../client')
 const commonFlags = require('../../common-flags')
@@ -33,7 +33,7 @@ class OpenDeveloperConsoleCommand extends Command {
         let result
 
         try {
-            result = await this.getDeveloperConsoleUrl(programId, args.environmentId, flags.passphrase)
+            result = await this.getDeveloperConsoleUrl(programId, sanitizeEnvironmentId(args.environmentId), flags.passphrase)
         } catch (error) {
             this.error(error.message)
         }

--- a/src/commands/cloudmanager/set-environment-variables.js
+++ b/src/commands/cloudmanager/set-environment-variables.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 const BaseEnvironmentVariablesCommand = require('../../base-environment-variables-command')
 const BaseVariablesCommand = require('../../base-variables-command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId } = require('../../cloudmanager-helpers')
+const { getApiKey, getOrgId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const Client = require('../../client')
 const commonFlags = require('../../common-flags')
 
@@ -32,7 +32,7 @@ class SetEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
     }
 
     async setVariables(programId, args, variables, passphrase = null) {
-        return _setEnvironmentVariables(programId, args.environmentId, variables, passphrase)
+        return _setEnvironmentVariables(programId, sanitizeEnvironmentId(args.environmentId), variables, passphrase)
     }
 }
 

--- a/src/commands/cloudmanager/tail-log.js
+++ b/src/commands/cloudmanager/tail-log.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command} = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const Client = require('../../client')
 const commonFlags = require('../../common-flags')
 
@@ -32,7 +32,7 @@ class TailLog extends Command {
         let result
 
         try {
-            result = await this.tailLog(programId, args.environmentId, args.service, args.name, flags.passphrase)
+            result = await this.tailLog(programId, sanitizeEnvironmentId(args.environmentId), args.service, args.name, flags.passphrase)
         } catch (error) {
             this.error(error.message)
         }

--- a/test/commands/list-environment-variables.test.js
+++ b/test/commands/list-environment-variables.test.js
@@ -160,3 +160,28 @@ test('list-environment-variables - success', async () => {
         "type": "secretString"
     })).toBe("****")
 })
+
+test('list-environment-variables for "e" prefixed env id - success', async () => {
+    setStore({
+        'jwt-auth': JSON.stringify({
+            client_id: '1234',
+            jwt_payload: {
+                iss: "good"
+            }
+        }),
+        'cloudmanager_programid': "4"
+    })
+
+    expect.assertions(2)
+
+    let runResult = ListEnvironmentVariablesCommand.run(["e1"])
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).resolves.toMatchObject([{
+        "name" : "KEY",
+        "type": "string",
+        "value" : "value"
+    },{
+        "name" : "I_AM_A_SECRET",
+        "type": "secretString"
+    }])
+})


### PR DESCRIPTION
## Description

just a convenience feature, in the cloud manager UI the environment ids show with an "e" prefix, allowing the e as prefix to be passed in would be nice

## Motivation and Context

see description

## How Has This Been Tested?

Tested it locally (used `aio plugins:link`)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
