### PR TITLE
Allow to use 'e'-prefixed env ids as found in cloud manager URLs 

### DIFF
--- a/src/base-environment-variables-command.js
+++ b/src/base-environment-variables-command.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId } = require('./cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, sanitizeEnvironmentId } = require('./cloudmanager-helpers')
 const BaseVariablesCommand = require('./base-variables-command')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 
@@ -26,7 +26,8 @@ async function _getEnvironmentVariables (programId, environmentId, passphrase) {
 
 class BaseEnvironmentVariablesCommand extends BaseVariablesCommand {
   async getVariables (programId, args, passphrase = null) {
-    return _getEnvironmentVariables(programId, args.environmentId, passphrase)
+    const environmentId = sanitizeEnvironmentId(args.environmentId)
+    return _getEnvironmentVariables(programId, environmentId, passphrase)
   }
 }
 

--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -81,10 +81,19 @@ function createKeyValueObjectFromFlag (flag) {
   }
 }
 
+function sanitizeEnvironmentId (environmentId) {
+  let envId = environmentId
+  if (envId && envId.startsWith('e')) {
+    envId = envId.substring(1)
+  }
+  return envId
+}
+
 module.exports = {
   getBaseUrl,
   getApiKey,
   getOrgId,
   getProgramId,
-  createKeyValueObjectFromFlag
+  createKeyValueObjectFromFlag,
+  sanitizeEnvironmentId
 }

--- a/src/commands/cloudmanager/delete-environment.js
+++ b/src/commands/cloudmanager/delete-environment.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
@@ -32,13 +32,15 @@ class DeleteEnvironmentCommand extends Command {
 
     const programId = await getProgramId(flags)
 
+    const environmentId = sanitizeEnvironmentId(args.environmentId)
+
     let result
 
     cli.action.start('deleting environment')
 
     try {
-      result = await this.deleteEnvironment(programId, args.environmentId, flags.passphrase)
-      cli.action.stop(`deleted environment ID ${args.environmentId}`)
+      result = await this.deleteEnvironment(programId, environmentId, flags.passphrase)
+      cli.action.stop(`deleted environment ID ${environmentId}`)
     } catch (error) {
       cli.action.stop(error.message)
       return

--- a/src/commands/cloudmanager/download-logs.js
+++ b/src/commands/cloudmanager/download-logs.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command, flags } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const path = require('path')
 const { init } = require('@adobe/aio-lib-cloudmanager')
@@ -33,6 +33,8 @@ class DownloadLogs extends Command {
 
     const programId = await getProgramId(flags)
 
+    const environmentId = sanitizeEnvironmentId(args.environmentId)
+
     const outputDirectory = flags.outputDirectory || '.'
 
     cli.action.start('downloading logs')
@@ -40,7 +42,7 @@ class DownloadLogs extends Command {
     let result
 
     try {
-      result = await this.downloadLogs(programId, args.environmentId, args.service, args.name, args.days, outputDirectory, flags.passphrase)
+      result = await this.downloadLogs(programId, environmentId, args.service, args.name, args.days, outputDirectory, flags.passphrase)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/list-available-log-options.js
+++ b/src/commands/cloudmanager/list-available-log-options.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
@@ -32,10 +32,12 @@ class ListAvailableLogOptionsCommand extends Command {
 
     const programId = await getProgramId(flags)
 
+    const environmentId = sanitizeEnvironmentId(args.environmentId)
+
     let result
 
     try {
-      result = await this.listAvailableLogOptions(programId, args.environmentId, flags.passphrase)
+      result = await this.listAvailableLogOptions(programId, environmentId, flags.passphrase)
     } catch (error) {
       this.error(error.message)
     }
@@ -44,7 +46,7 @@ class ListAvailableLogOptionsCommand extends Command {
       cli.table(result, {
         id: {
           header: 'Environment Id',
-          get: () => args.environmentId
+          get: () => environmentId
         },
         service: {},
         name: {}
@@ -52,7 +54,7 @@ class ListAvailableLogOptionsCommand extends Command {
         printLine: this.log
       })
     } else {
-      cli.info(`No log options are available for environmentId ${args.environmentId}`)
+      cli.info(`No log options are available for environmentId ${environmentId}`)
     }
 
     return result

--- a/src/commands/cloudmanager/open-developer-console.js
+++ b/src/commands/cloudmanager/open-developer-console.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
@@ -32,10 +32,12 @@ class OpenDeveloperConsoleCommand extends Command {
 
     const programId = await getProgramId(flags)
 
+    const environmentId = sanitizeEnvironmentId(args.environmentId)
+
     let result
 
     try {
-      result = await this.getDeveloperConsoleUrl(programId, args.environmentId, flags.passphrase)
+      result = await this.getDeveloperConsoleUrl(programId, environmentId, flags.passphrase)
     } catch (error) {
       this.error(error.message)
     }

--- a/src/commands/cloudmanager/set-environment-variables.js
+++ b/src/commands/cloudmanager/set-environment-variables.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 const BaseEnvironmentVariablesCommand = require('../../base-environment-variables-command')
 const BaseVariablesCommand = require('../../base-variables-command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
 
@@ -34,7 +34,8 @@ class SetEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
   }
 
   async setVariables (programId, args, variables, passphrase = null) {
-    return _setEnvironmentVariables(programId, args.environmentId, variables, passphrase)
+    const environmentId = sanitizeEnvironmentId(args.environmentId)
+    return _setEnvironmentVariables(programId, environmentId, variables, passphrase)
   }
 }
 

--- a/src/commands/cloudmanager/tail-log.js
+++ b/src/commands/cloudmanager/tail-log.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
 
@@ -31,10 +31,12 @@ class TailLog extends Command {
 
     const programId = await getProgramId(flags)
 
+    const environmentId = sanitizeEnvironmentId(args.environmentId)
+
     let result
 
     try {
-      result = await this.tailLog(programId, args.environmentId, args.service, args.name, flags.passphrase)
+      result = await this.tailLog(programId, environmentId, args.service, args.name, flags.passphrase)
     } catch (error) {
       this.error(error.message)
     }

--- a/test/commands/list-environment-variables.test.js
+++ b/test/commands/list-environment-variables.test.js
@@ -74,3 +74,28 @@ test('list-environment-variables - success', async () => {
     value: 'value'
   })).toBe('value')
 })
+
+test('list-environment-variables for "e" prefixed env id - success', async () => {
+  setStore({
+    'jwt-auth': JSON.stringify({
+      client_id: '1234',
+      jwt_payload: {
+        iss: 'good'
+      }
+    }),
+    cloudmanager_programid: '4'
+  })
+
+  expect.assertions(2)
+
+  const runResult = ListEnvironmentVariablesCommand.run(['e1'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).resolves.toMatchObject([{
+    name: 'KEY',
+    type: 'string',
+    value: 'value'
+  }, {
+    name: 'I_AM_A_SECRET',
+    type: 'secretString'
+  }])
+})


### PR DESCRIPTION
(h/t @ghenzler). fixes #140

<!--- Provide a general summary of your changes in the Title above -->

## Description

Anywhere an environment id is taken, it also accepts an e prefixed value

## Related Issue

#140

## Motivation and Context

Some minor annoyance

## How Has This Been Tested?

Unit tests
Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
