### PR TITLE
[#147] Support for JSON and YAML output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,10 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/get-current-execution.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/get-current-execution.js)_
@@ -308,8 +310,10 @@ ARGUMENTS
   EXECUTIONID  the execution id
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/get-execution-step-details.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/get-execution-step-details.js)_
@@ -354,8 +358,10 @@ ARGUMENTS
   ACTION       (codeQuality|security|performance|contentAudit|experienceAudit) the step action
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/get-quality-gate-results.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/get-quality-gate-results.js)_
@@ -372,8 +378,10 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/list-available-log-options.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/list-available-log-options.js)_
@@ -387,8 +395,10 @@ USAGE
   $ aio cloudmanager:list-current-executions
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/list-current-executions.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/list-current-executions.js)_
@@ -405,8 +415,10 @@ ARGUMENTS
   ENVIRONMENTID  the environment id
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/list-environment-variables.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/list-environment-variables.js)_
@@ -420,8 +432,10 @@ USAGE
   $ aio cloudmanager:list-environments
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/list-environments.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/list-environments.js)_
@@ -438,8 +452,10 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/list-pipeline-variables.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/list-pipeline-variables.js)_
@@ -453,8 +469,10 @@ USAGE
   $ aio cloudmanager:list-pipelines
 
 OPTIONS
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/list-pipelines.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/list-pipelines.js)_
@@ -469,7 +487,9 @@ USAGE
 
 OPTIONS
   -e, --enabledonly            only output Cloud Manager-enabled programs
+  -j, --json                   output in json
   -r, --passphrase=passphrase  the passphrase for the private-key
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/list-programs.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/list-programs.js)_
@@ -505,10 +525,12 @@ ARGUMENTS
 
 OPTIONS
   -d, --delete=delete          variables/secrets to delete
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
   -s, --secret=secret          secret values in KEY VALUE format
   -v, --variable=variable      variable values in KEY VALUE format
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/set-environment-variables.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/set-environment-variables.js)_
@@ -526,10 +548,12 @@ ARGUMENTS
 
 OPTIONS
   -d, --delete=delete          variables/secrets to delete
+  -j, --json                   output in json
   -p, --programId=programId    the programId. if not specified, defaults to 'cloudmanager_programid' config value
   -r, --passphrase=passphrase  the passphrase for the private-key
   -s, --secret=secret          secret values in KEY VALUE format
   -v, --variable=variable      variable values in KEY VALUE format
+  -y, --yaml                   output in yaml
 ```
 
 _See code: [src/commands/cloudmanager/set-pipeline-variables.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/0.14.1/src/commands/cloudmanager/set-pipeline-variables.js)_

--- a/src/base-execution-command.js
+++ b/src/base-execution-command.js
@@ -13,9 +13,11 @@ governing permissions and limitations under the License.
 const { Command } = require('@oclif/command')
 const { cli } = require('cli-ux')
 const { getCurrentStep } = require('@adobe/aio-lib-cloudmanager')
+const { getOutputFormat } = require('./cloudmanager-helpers')
+const commonFlags = require('./common-flags')
 
 class BaseExecutionCommand extends Command {
-  outputTable (result) {
+  outputTable (result, flags) {
     cli.table(result, {
       pipelineId: {
         header: 'Pipeline Id'
@@ -32,9 +34,14 @@ class BaseExecutionCommand extends Command {
         get: item => getCurrentStep(item).status
       }
     }, {
-      printLine: this.log
+      printLine: this.log,
+      output: await getOutputFormat(flags)
     })
   }
+}
+
+BaseExecutionCommand.flags = {
+  ...commonFlags.outputFormat
 }
 
 module.exports = BaseExecutionCommand

--- a/src/base-execution-command.js
+++ b/src/base-execution-command.js
@@ -35,7 +35,7 @@ class BaseExecutionCommand extends Command {
       }
     }, {
       printLine: this.log,
-      output: await getOutputFormat(flags)
+      output: getOutputFormat(flags)
     })
   }
 }

--- a/src/base-variables-command.js
+++ b/src/base-variables-command.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 const { Command } = require('@oclif/command')
 const { cli } = require('cli-ux')
 const { flags } = require('@oclif/command')
-const { getProgramId, createKeyValueObjectFromFlag } = require('./cloudmanager-helpers')
+const { getProgramId, createKeyValueObjectFromFlag, getOutputFormat } = require('./cloudmanager-helpers')
 const commonFlags = require('./common-flags')
 
 class BaseVariablesCommand extends Command {
@@ -25,7 +25,7 @@ class BaseVariablesCommand extends Command {
         get: (item) => item.type === 'secretString' ? '****' : item.value
       }
     }, {
-      output: await getOutputFormat(flags)
+      output: getOutputFormat(flags)
     })
   }
 

--- a/src/base-variables-command.js
+++ b/src/base-variables-command.js
@@ -14,15 +14,18 @@ const { Command } = require('@oclif/command')
 const { cli } = require('cli-ux')
 const { flags } = require('@oclif/command')
 const { getProgramId, createKeyValueObjectFromFlag } = require('./cloudmanager-helpers')
+const commonFlags = require('./common-flags')
 
 class BaseVariablesCommand extends Command {
-  outputTable (result) {
+  outputTable (result, flags) {
     cli.table(result, {
       name: {},
       type: {},
       value: {
         get: (item) => item.type === 'secretString' ? '****' : item.value
       }
+    }, {
+      output: await getOutputFormat(flags)
     })
   }
 
@@ -48,7 +51,7 @@ class BaseVariablesCommand extends Command {
     } catch (error) {
       this.error(error.message)
     }
-    this.outputTable(result)
+    this.outputTable(result, flags)
 
     return result
   }
@@ -98,7 +101,7 @@ class BaseVariablesCommand extends Command {
   }
 }
 
-BaseVariablesCommand.flags = {
+BaseVariablesCommand.setterFlags = {
   variable: flags.string({
     char: 'v',
     description: 'variable values in KEY VALUE format',
@@ -113,7 +116,12 @@ BaseVariablesCommand.flags = {
     char: 'd',
     description: 'variables/secrets to delete',
     multiple: true
-  })
+  }),
+  ...commonFlags.outputFormat
+}
+
+BaseVariablesCommand.getterFlags = {
+  ...commonFlags.outputFormat
 }
 
 module.exports = BaseVariablesCommand

--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -62,7 +62,7 @@ async function getProgramId (flags) {
   return programId
 }
 
-async function getOutputFormat (flags) {
+function getOutputFormat (flags) {
   if (flags.json) {
     return 'json'
   }

--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -62,6 +62,15 @@ async function getProgramId (flags) {
   return programId
 }
 
+async function getOutputFormat (flags) {
+  if (flags.json) {
+    return 'json'
+  }
+  if (flags.yaml) {
+    return 'yaml'
+  }
+}
+
 function createKeyValueObjectFromFlag (flag) {
   if (flag.length % 2 === 0) {
     let i
@@ -94,6 +103,7 @@ module.exports = {
   getApiKey,
   getOrgId,
   getProgramId,
+  getOutputFormat,
   createKeyValueObjectFromFlag,
   sanitizeEnvironmentId
 }

--- a/src/commands/cloudmanager/get-current-execution.js
+++ b/src/commands/cloudmanager/get-current-execution.js
@@ -39,7 +39,7 @@ class GetCurrentExecutionCommand extends BaseExecutionCommand {
       this.error(error.message)
     }
 
-    this.outputTable([result])
+    this.outputTable([result], flags)
 
     return result
   }
@@ -53,7 +53,8 @@ GetCurrentExecutionCommand.description = 'get pipeline execution'
 
 GetCurrentExecutionCommand.flags = {
   ...commonFlags.global,
-  ...commonFlags.programId
+  ...commonFlags.programId,
+  ...BaseExecutionCommand.flags
 }
 
 GetCurrentExecutionCommand.args = [

--- a/src/commands/cloudmanager/get-execution-step-details.js
+++ b/src/commands/cloudmanager/get-execution-step-details.js
@@ -95,7 +95,7 @@ class GetExecutionStepDetails extends Command {
         }
       }, {
         printLine: this.log,
-        output: await getOutputFormat(flags)
+        output: getOutputFormat(flags)
       })
 
       return stepStates

--- a/src/commands/cloudmanager/get-execution-step-details.js
+++ b/src/commands/cloudmanager/get-execution-step-details.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const _ = require('lodash')
 const halfred = require('halfred')
@@ -94,7 +94,8 @@ class GetExecutionStepDetails extends Command {
           get: formatDuration
         }
       }, {
-        printLine: this.log
+        printLine: this.log,
+        output: await getOutputFormat(flags)
       })
 
       return stepStates
@@ -112,6 +113,7 @@ GetExecutionStepDetails.description = 'get execution step details'
 
 GetExecutionStepDetails.flags = {
   ...commonFlags.global,
+  ...commonFlags.outputFormat,
   ...commonFlags.programId
 }
 

--- a/src/commands/cloudmanager/get-quality-gate-results.js
+++ b/src/commands/cloudmanager/get-quality-gate-results.js
@@ -83,7 +83,7 @@ class GetQualityGateResults extends Command {
       }
     }, {
       printLine: this.log,
-      output: await getOutputFormat(flags)
+      output: getOutputFormat(flags)
     })
 
     return result

--- a/src/commands/cloudmanager/get-quality-gate-results.js
+++ b/src/commands/cloudmanager/get-quality-gate-results.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const _ = require('lodash')
 const { init } = require('@adobe/aio-lib-cloudmanager')
@@ -82,7 +82,8 @@ class GetQualityGateResults extends Command {
         get: item => item.passed ? 'Yes' : 'No'
       }
     }, {
-      printLine: this.log
+      printLine: this.log,
+      output: await getOutputFormat(flags)
     })
 
     return result
@@ -97,6 +98,7 @@ GetQualityGateResults.description = 'get quality gate results'
 
 GetQualityGateResults.flags = {
   ...commonFlags.global,
+  ...commonFlags.outputFormat,
   ...commonFlags.programId
 }
 

--- a/src/commands/cloudmanager/list-available-log-options.js
+++ b/src/commands/cloudmanager/list-available-log-options.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, sanitizeEnvironmentId, getOutputFormat } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
@@ -51,7 +51,8 @@ class ListAvailableLogOptionsCommand extends Command {
         service: {},
         name: {}
       }, {
-        printLine: this.log
+        printLine: this.log,
+        output: await getOutputFormat(flags)
       })
     } else {
       cli.info(`No log options are available for environmentId ${environmentId}`)
@@ -73,6 +74,7 @@ ListAvailableLogOptionsCommand.args = [
 
 ListAvailableLogOptionsCommand.flags = {
   ...commonFlags.global,
+  ...commonFlags.outputFormat,
   ...commonFlags.programId
 }
 

--- a/src/commands/cloudmanager/list-available-log-options.js
+++ b/src/commands/cloudmanager/list-available-log-options.js
@@ -52,7 +52,7 @@ class ListAvailableLogOptionsCommand extends Command {
         name: {}
       }, {
         printLine: this.log,
-        output: await getOutputFormat(flags)
+        output: getOutputFormat(flags)
       })
     } else {
       cli.info(`No log options are available for environmentId ${environmentId}`)

--- a/src/commands/cloudmanager/list-current-executions.js
+++ b/src/commands/cloudmanager/list-current-executions.js
@@ -42,7 +42,7 @@ class ListCurrentExecutionsCommand extends BaseExecutionCommand {
       this.error(error.message)
     }
 
-    this.outputTable(result)
+    this.outputTable(result, flags)
 
     return result
   }
@@ -56,7 +56,8 @@ ListCurrentExecutionsCommand.description = 'list running pipeline executions'
 
 ListCurrentExecutionsCommand.flags = {
   ...commonFlags.global,
-  ...commonFlags.programId
+  ...commonFlags.programId,
+  ...BaseExecutionCommand.flags
 }
 
 module.exports = ListCurrentExecutionsCommand

--- a/src/commands/cloudmanager/list-environment-variables.js
+++ b/src/commands/cloudmanager/list-environment-variables.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const BaseEnvironmentVariablesCommand = require('../../base-environment-variables-command')
 const BaseVariablesCommand = require('../../base-variables-command')
-const { getProgramId, getOutputFormat } = require('../../cloudmanager-helpers')
+const { getProgramId } = require('../../cloudmanager-helpers')
 const commonFlags = require('../../common-flags')
 
 class ListEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {

--- a/src/commands/cloudmanager/list-environment-variables.js
+++ b/src/commands/cloudmanager/list-environment-variables.js
@@ -11,7 +11,8 @@ governing permissions and limitations under the License.
 */
 
 const BaseEnvironmentVariablesCommand = require('../../base-environment-variables-command')
-const { getProgramId } = require('../../cloudmanager-helpers')
+const BaseVariablesCommand = require('../../base-variables-command')
+const { getProgramId, getOutputFormat } = require('../../cloudmanager-helpers')
 const commonFlags = require('../../common-flags')
 
 class ListEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
@@ -27,7 +28,7 @@ class ListEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
     } catch (error) {
       this.error(error.message)
     }
-    this.outputTable(result)
+    this.outputTable(result, flags)
 
     return result
   }
@@ -41,7 +42,8 @@ ListEnvironmentVariablesCommand.args = [
 
 ListEnvironmentVariablesCommand.flags = {
   ...commonFlags.global,
-  ...commonFlags.programId
+  ...commonFlags.programId,
+  ...BaseVariablesCommand.getterFlags
 }
 
 module.exports = ListEnvironmentVariablesCommand

--- a/src/commands/cloudmanager/list-environments.js
+++ b/src/commands/cloudmanager/list-environments.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
@@ -51,7 +51,8 @@ class ListEnvironmentsCommand extends Command {
         get: item => item.description ? item.description : ''
       }
     }, {
-      printLine: this.log
+      printLine: this.log,
+      output: await getOutputFormat(flags)
     })
 
     return result
@@ -66,6 +67,7 @@ ListEnvironmentsCommand.description = 'lists environments available in a Cloud M
 
 ListEnvironmentsCommand.flags = {
   ...commonFlags.global,
+  ...commonFlags.outputFormat,
   ...commonFlags.programId
 }
 

--- a/src/commands/cloudmanager/list-environments.js
+++ b/src/commands/cloudmanager/list-environments.js
@@ -52,7 +52,7 @@ class ListEnvironmentsCommand extends Command {
       }
     }, {
       printLine: this.log,
-      output: await getOutputFormat(flags)
+      output: getOutputFormat(flags)
     })
 
     return result

--- a/src/commands/cloudmanager/list-pipeline-variables.js
+++ b/src/commands/cloudmanager/list-pipeline-variables.js
@@ -28,7 +28,7 @@ class ListPipelineVariablesCommand extends BasePipelineVariablesCommand {
     } catch (error) {
       this.error(error.message)
     }
-    this.outputTable(result)
+    this.outputTable(result, flags)
 
     return result
   }

--- a/src/commands/cloudmanager/list-pipeline-variables.js
+++ b/src/commands/cloudmanager/list-pipeline-variables.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const BasePipelineVariablesCommand = require('../../base-pipeline-variables-command')
+const BaseVariablesCommand = require('../../base-variables-command')
 const { getProgramId } = require('../../cloudmanager-helpers')
 const commonFlags = require('../../common-flags')
 
@@ -41,7 +42,8 @@ ListPipelineVariablesCommand.args = [
 
 ListPipelineVariablesCommand.flags = {
   ...commonFlags.global,
-  ...commonFlags.programId
+  ...commonFlags.programId,
+  ...BaseVariablesCommand.getterFlags
 }
 
 module.exports = ListPipelineVariablesCommand

--- a/src/commands/cloudmanager/list-pipelines.js
+++ b/src/commands/cloudmanager/list-pipelines.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId, getProgramId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getProgramId, getOutputFormat } = require('../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const commonFlags = require('../../common-flags')
@@ -47,7 +47,8 @@ class ListPipelinesCommand extends Command {
       name: {},
       status: {}
     }, {
-      printLine: this.log
+      printLine: this.log,
+      output: await getOutputFormat(flags)
     })
 
     return result
@@ -62,6 +63,7 @@ ListPipelinesCommand.description = 'lists pipelines available in a Cloud Manager
 
 ListPipelinesCommand.flags = {
   ...commonFlags.global,
+  ...commonFlags.outputFormat,
   ...commonFlags.programId
 }
 

--- a/src/commands/cloudmanager/list-pipelines.js
+++ b/src/commands/cloudmanager/list-pipelines.js
@@ -48,7 +48,7 @@ class ListPipelinesCommand extends Command {
       status: {}
     }, {
       printLine: this.log,
-      output: await getOutputFormat(flags)
+      output: getOutputFormat(flags)
     })
 
     return result

--- a/src/commands/cloudmanager/list-programs.js
+++ b/src/commands/cloudmanager/list-programs.js
@@ -49,7 +49,7 @@ class ListProgramsCommand extends Command {
       enabled: {}
     }, {
       printLine: this.log,
-      output: await getOutputFormat(flags)
+      output: getOutputFormat(flags)
     })
 
     return result

--- a/src/commands/cloudmanager/list-programs.js
+++ b/src/commands/cloudmanager/list-programs.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command, flags } = require('@oclif/command')
 const { accessToken: getAccessToken } = require('@adobe/aio-cli-plugin-jwt-auth')
-const { getApiKey, getBaseUrl, getOrgId } = require('../../cloudmanager-helpers')
+const { getApiKey, getBaseUrl, getOrgId, getOutputFormat } = require('../../cloudmanager-helpers')
 const { init } = require('@adobe/aio-lib-cloudmanager')
 const { cli } = require('cli-ux')
 const commonFlags = require('../../common-flags')
@@ -48,7 +48,8 @@ class ListProgramsCommand extends Command {
       name: {},
       enabled: {}
     }, {
-      printLine: this.log
+      printLine: this.log,
+      output: await getOutputFormat(flags)
     })
 
     return result
@@ -63,6 +64,7 @@ ListProgramsCommand.description = 'lists programs available in Cloud Manager'
 
 ListProgramsCommand.flags = {
   ...commonFlags.global,
+  ...commonFlags.outputFormat,
   enabledonly: flags.boolean({ char: 'e', description: 'only output Cloud Manager-enabled programs' })
 }
 

--- a/src/commands/cloudmanager/set-environment-variables.js
+++ b/src/commands/cloudmanager/set-environment-variables.js
@@ -48,7 +48,7 @@ SetEnvironmentVariablesCommand.args = [
 SetEnvironmentVariablesCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
-  ...BaseVariablesCommand.flags
+  ...BaseVariablesCommand.setterFlags
 }
 
 module.exports = SetEnvironmentVariablesCommand

--- a/src/commands/cloudmanager/set-pipeline-variables.js
+++ b/src/commands/cloudmanager/set-pipeline-variables.js
@@ -47,7 +47,7 @@ SetPipelineVariablesCommand.args = [
 SetPipelineVariablesCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
-  ...BaseVariablesCommand.flags
+  ...BaseVariablesCommand.setterFlags
 }
 
 module.exports = SetPipelineVariablesCommand

--- a/src/common-flags.js
+++ b/src/common-flags.js
@@ -17,5 +17,9 @@ module.exports = {
   },
   programId: {
     programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" })
+  },
+  outputFormat: {
+    json: flags.string({ char: 'j', description: "output in json format" }),
+    yaml: flags.string({ char: 'y', description: "output in yaml format" })
   }
 }

--- a/src/common-flags.js
+++ b/src/common-flags.js
@@ -19,7 +19,7 @@ module.exports = {
     programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" })
   },
   outputFormat: {
-    json: flags.boolean({ char: 'j', description: "output in json format" }),
-    yaml: flags.boolean({ char: 'y', description: "output in yaml format" })
+    json: flags.boolean({ char: 'j', description: 'output in json format' }),
+    yaml: flags.boolean({ char: 'y', description: 'output in yaml format' })
   }
 }

--- a/src/common-flags.js
+++ b/src/common-flags.js
@@ -19,7 +19,7 @@ module.exports = {
     programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" })
   },
   outputFormat: {
-    json: flags.string({ char: 'j', description: "output in json format" }),
-    yaml: flags.string({ char: 'y', description: "output in yaml format" })
+    json: flags.boolean({ char: 'j', description: "output in json format" }),
+    yaml: flags.boolean({ char: 'y', description: "output in yaml format" })
   }
 }

--- a/src/common-flags.js
+++ b/src/common-flags.js
@@ -19,7 +19,7 @@ module.exports = {
     programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" })
   },
   outputFormat: {
-    json: flags.boolean({ char: 'j', description: 'output in json format' }),
+    json: flags.boolean({ char: 'j', description: 'output in json format', exclusive: ['yaml'] }),
     yaml: flags.boolean({ char: 'y', description: 'output in yaml format' })
   }
 }

--- a/test/cloudmanager-helpers.test.js
+++ b/test/cloudmanager-helpers.test.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const Config = require('@adobe/aio-lib-core-config')
-const { getApiKey, getOrgId, getBaseUrl } = require('../src/cloudmanager-helpers')
+const { getApiKey, getOrgId, getBaseUrl, getOutputFormat } = require('../src/cloudmanager-helpers')
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -82,4 +82,10 @@ test('getBaseUrl', async () => {
   // cloudmanager key, some base url
   jest.spyOn(Config, 'get').mockImplementation(() => JSON.stringify({ base_url: 'https://www.adobe.com' }))
   await expect(getBaseUrl()).resolves.toEqual('https://www.adobe.com')
+})
+
+test('getOutputFormat', () => {
+  expect(getOutputFormat({})).toBeUndefined()
+  expect(getOutputFormat({ json: true })).toBe('json')
+  expect(getOutputFormat({ yaml: true })).toBe('yaml')
 })


### PR DESCRIPTION
Added options to allow the user to control the output format for commands which render a table. The two new options are:

```
  -j, --json                   output in json
  -y, --yaml                   output in yaml
```

## Description

1. Introduced a common function and flags to support user control over the output format.
2. Added options for json and yaml
3. Implemented output on commands which render a table
4. Updated README to show new options

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#147 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Allow for machine consumable outputs

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Introduced new tests
Ran existing tests
Manual testing on mac running catalina

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
