### PR TITLE
feat(various): implement loading environmentId from configuration. fi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ For example
 $ aio config:set cloudmanager_programid 4
 ```
 
+## Set Default Environment
+
+If you want to avoid passing the environment ID argument repeatedly, you can configure it using:
+
+```sh-session
+$ aio config:set cloudmanager_environmentid ENVIRONMENTID
+```
+
+For example
+
+```sh-session
+$ aio config:set cloudmanager_environmentid 7
+```
+
+> This only works for commands where the environmentId is the **first** argument.
+
 # Commands
 <!-- commands -->
 * [`aio cloudmanager`](#aio-cloudmanager)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@adobe/aio-lib-core-config": "^1.2.8",
     "@oclif/command": "^1.6.1",
     "@oclif/config": "^1.15.1",
+    "@oclif/parser": "^3.8.5",
     "@oclif/plugin-help": "^2.2.3",
     "cli-ux": "^5.4.6",
     "halfred": "^2.0.0",
@@ -60,7 +61,10 @@
     "devPlugins": [
       "@oclif/plugin-help"
     ],
-    "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>"
+    "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>",
+    "hooks": {
+      "prerun": "./src/hooks/prerun/environment-id-from-config"
+    }
   },
   "main": "src/index.js",
   "repository": {

--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -98,6 +98,10 @@ function sanitizeEnvironmentId (environmentId) {
   return envId
 }
 
+async function getDefaultEnvironmentId (flags) {
+  return await Config.get('cloudmanager_environmentid')
+}
+
 module.exports = {
   getBaseUrl,
   getApiKey,
@@ -105,5 +109,6 @@ module.exports = {
   getProgramId,
   getOutputFormat,
   createKeyValueObjectFromFlag,
-  sanitizeEnvironmentId
+  sanitizeEnvironmentId,
+  getDefaultEnvironmentId
 }

--- a/src/hooks/prerun/environment-id-from-config.js
+++ b/src/hooks/prerun/environment-id-from-config.js
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { getDefaultEnvironmentId } = require('../../cloudmanager-helpers')
+
+const { RequiredArgsError } = require('@oclif/parser/lib/errors')
+
+function hasEnvironmentIdAsFirstArg (options) {
+  return options.Command.args && options.Command.args[0].name === 'environmentId'
+}
+
+module.exports = async function (hookOptions) {
+  if (hasEnvironmentIdAsFirstArg(hookOptions)) {
+    const environmentId = await getDefaultEnvironmentId()
+    if (environmentId) {
+      const originalParse = hookOptions.Command.prototype.parse
+      hookOptions.Command.prototype.parse = function (options) {
+        try {
+          return originalParse.call(this, options)
+        } catch (e) {
+          if (e instanceof RequiredArgsError && e.args && e.args.length === 1 && e.args[0].name === 'environmentId') {
+            return originalParse.call(this, options, [environmentId, ...hookOptions.argv])
+          } else {
+            throw e
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/hooks/prerun/environment-id-from-config.test.js
+++ b/test/hooks/prerun/environment-id-from-config.test.js
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { setStore } = require('@adobe/aio-lib-core-config')
+const { RequiredArgsError, RequiredFlagError } = require('@oclif/parser/lib/errors')
+const hook = require('../../../src/hooks/prerun/environment-id-from-config')
+
+let parse
+
+beforeEach(() => {
+  setStore({})
+  parse = jest.fn()
+})
+
+test('hook -- no args and no config', async () => {
+  expect.assertions(1)
+
+  await hook({
+    Command: FixtureWithNoArgs,
+    argv: []
+  })
+  new FixtureWithNoArgs().parse(FixtureWithNoArgs, [])
+  expect(parse.mock.calls.length).toEqual(1)
+})
+
+test('hook -- environmentId args and no config', async () => {
+  expect.assertions(1)
+
+  await hook({
+    Command: FixtureWithEnvironmentIdArg,
+    argv: []
+  })
+  new FixtureWithNoArgs().parse(FixtureWithEnvironmentIdArg, [])
+  expect(parse.mock.calls.length).toEqual(1)
+})
+
+test('hook -- environmentId args with config', async () => {
+  setStore({
+    cloudmanager_environmentid: '4321'
+  })
+
+  parse = jest.fn().mockImplementationOnce(() => {
+    throw new RequiredArgsError({ args: [{ name: 'environmentId' }] })
+  }).mockImplementationOnce(() => true)
+
+  expect.assertions(2)
+
+  await hook({
+    Command: FixtureWithEnvironmentIdArg,
+    argv: []
+  })
+  new FixtureWithEnvironmentIdArg().parse(FixtureWithEnvironmentIdArg, [])
+  expect(parse.mock.calls.length).toEqual(2)
+  expect(parse.mock.calls[1][1]).toEqual(['4321'])
+})
+
+test('hook -- multiple missing args with config', async () => {
+  setStore({
+    cloudmanager_environmentid: '4321'
+  })
+
+  parse = jest.fn().mockImplementationOnce(() => {
+    throw new RequiredArgsError({ args: [{ name: 'environmentId' }, { name: 'pipelineId' }] })
+  })
+
+  expect.assertions(2)
+
+  await hook({
+    Command: FixtureWithOtherArgs,
+    argv: []
+  })
+  expect(() => new FixtureWithOtherArgs().parse(FixtureWithOtherArgs, [])).toThrow(RequiredArgsError)
+  expect(parse.mock.calls.length).toEqual(1)
+})
+
+test('hook -- different error', async () => {
+  setStore({
+    cloudmanager_environmentid: '4321'
+  })
+
+  parse = jest.fn().mockImplementationOnce(() => {
+    throw new RequiredFlagError({ flag: { name: 'test' } })
+  })
+
+  expect.assertions(2)
+
+  await hook({
+    Command: FixtureWithEnvironmentIdArg,
+    argv: []
+  })
+  expect(() => new FixtureWithEnvironmentIdArg().parse(FixtureWithEnvironmentIdArg, [])).toThrow(RequiredFlagError)
+  expect(parse.mock.calls.length).toEqual(1)
+})
+
+class FixtureWithNoArgs {
+  parse (options, argv) {
+    parse(options, argv)
+  }
+}
+
+class FixtureWithEnvironmentIdArg {
+  parse (options, argv) {
+    parse(options, argv)
+  }
+}
+
+FixtureWithEnvironmentIdArg.args = [
+  { name: 'environmentId' }
+]
+
+class FixtureWithOtherArgs {
+  parse (options, argv) {
+    parse(options, argv)
+  }
+}
+
+FixtureWithOtherArgs.args = [
+  { name: 'pipelineId' },
+  { name: 'environmentId' }
+]


### PR DESCRIPTION
…xes #149

<!--- Provide a general summary of your changes in the Title above -->

## Description

Enables commands that accept an environmentId as the first argument to read the `cloudmanager_environmentid` configuration parameter

## Related Issue

#149 

## Motivation and Context

To avoid having to pass environmentIds over and over again.

## How Has This Been Tested?

* Unit tests
* Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
