### PR TITLE
fix(hook): validate ims context configuration from flag. fixes #237

### DIFF
--- a/src/hooks/prerun/check-ims-context-config.js
+++ b/src/hooks/prerun/check-ims-context-config.js
@@ -12,13 +12,21 @@ governing permissions and limitations under the License.
 const Config = require('@adobe/aio-lib-core-config')
 const { defaultContextName } = require('../../cloudmanager-helpers')
 
-const configKey = `ims.contexts.${defaultContextName}`
-
 const requiredKeys = ['client_id', 'client_secret', 'technical_account_id', 'meta_scopes', 'ims_org_id', 'private_key']
 
 const requiredMetaScope = 'ent_cloudmgr_sdk'
 
-module.exports = function () {
+function getContextName (options) {
+  if (options.Command && options.Command.flags && options.Command.flags.imsContextName) {
+    return options.Command.prototype.parse.call(this, options.Command, options.argv).flags.imsContextName
+  }
+}
+
+module.exports = function (hookOptions) {
+  const contextName = getContextName(hookOptions) || defaultContextName
+
+  const configKey = `ims.contexts.${contextName}`
+
   const config = Config.get(configKey)
 
   if (!config) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When validating the IMS context configuration, if an alternate configuration is specified using a flag, use it.

## Related Issue

#237 

## Motivation and Context

The purpose of validation is to check that the configuration is proper. If an alternate configuration is specified, that configuration should be validated instead of the default.

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
