### PR TITLE
fix(hook): only check ims context on commands for this plugin

### DIFF
--- a/src/hooks/prerun/check-ims-context-config.js
+++ b/src/hooks/prerun/check-ims-context-config.js
@@ -17,12 +17,16 @@ const requiredKeys = ['client_id', 'client_secret', 'technical_account_id', 'met
 const requiredMetaScope = 'ent_cloudmgr_sdk'
 
 function getContextName (options) {
-  if (options.Command && options.Command.flags && options.Command.flags.imsContextName) {
+  if (options.Command.flags && options.Command.flags.imsContextName) {
     return options.Command.prototype.parse.call(this, options.Command, options.argv).flags.imsContextName
   }
 }
 
 module.exports = function (hookOptions) {
+  const pluginName = hookOptions.Command.plugin.name
+  if (pluginName !== '@adobe/aio-cli-plugin-cloudmanager') {
+    return
+  }
   const contextName = getContextName(hookOptions) || defaultContextName
 
   const configKey = `ims.contexts.${contextName}`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The IMS context validation should only be done on commands from this plugin, otherwise you can't actually configure (unless you manually edit the .aio file which no one should)

## Related Issue

TBD

## Motivation and Context

Makes the plugin really hard to use

## How Has This Been Tested?

* Manual testing
* Unit testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
