### PR TITLE
fix(variables): fix how numeric values are parsed. fixes #253

### DIFF
--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -74,6 +74,9 @@ function createKeyValueObjectFromFlag (flag) {
       try {
         // assume it is JSON, there is only 1 way to find out
         tempObj[flag[i]] = JSON.parse(flag[i + 1])
+        if (typeof tempObj[flag[i]] === 'number') {
+          throw new Error('parsed flag value as a number')
+        }
       } catch (ex) {
         // hmm ... not json, treat as string
         tempObj[flag[i]] = flag[i + 1]

--- a/test/commands/environment/set-variables.test.js
+++ b/test/commands/environment/set-variables.test.js
@@ -130,6 +130,28 @@ test('set-environment-variables - variables only', async () => {
   }])
 })
 
+test('set-environment-variables - long numeric value', async () => {
+  setCurrentOrgId('good')
+  setStore({
+    cloudmanager_programid: '4',
+  })
+
+  expect.assertions(5)
+
+  const runResult = SetEnvironmentVariablesCommand.run(['1', '--variable', 'foo', '4566206088344615922'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await runResult
+  await expect(init.mock.calls.length).toEqual(3)
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(mockSdk.setEnvironmentVariables.mock.calls.length).toEqual(1)
+  await expect(mockSdk.setEnvironmentVariables).toHaveBeenCalledWith('4', '1', [{
+    name: 'foo',
+    type: 'string',
+    value: '4566206088344615922',
+  }])
+})
+
 test('set-environment-variables - secrets only', async () => {
   setCurrentOrgId('good')
   setStore({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Change how numeric flags are parsed by ignoring JSON-parsed numbers.

This is perhaps not the most elegant way to address this, but expedient.

## Related Issue

#253 

## Motivation and Context

This is very strange behavior and would not be detectable unless the numeric value was particularly high.

## How Has This Been Tested?

* Unit test
* Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
