### PR TITLE
fix(deps): force the use of @adobe/aio-lib-ims-jwt higher than 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-logging": "^1.2.0",
     "@adobe/aio-lib-ims": "^4.1.1",
+    "@adobe/aio-lib-ims-jwt": "^2.1.1",
     "@oclif/command": "^1.6.1",
     "@oclif/config": "^1.15.1",
     "@oclif/parser": "^3.8.5",


### PR DESCRIPTION
fixes #256 because @adobe/aio-lib-ims-jwt 2.1.1 removes requirement for technical_account_email field

<!--- Provide a general summary of your changes in the Title above -->

## Description

* Force version of @adobe/aio-lib-ims-jwt to 2.1.1 or higher

## Related Issue

#256 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manual local testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
