### PR TITLE
feat(auth): support selection and listing of Cloud Manager-authorized…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This command will open a browser window in which you will authenticate using you
 
 In addition to the authentication, the CLI needs to know the Adobe Organization Identifer (OrgId). There are two ways to do this:
 
-1. By running `aio console:org:select` and use the interactive menu.
+1. By running `aio cloudmanager:org:select` and use the interactive menu. By default this will store the selected organization in the current working directory, but the selection can also be stored globally by passing `--global` (see full command documentation below)
 2. By setting the identifier as the configuration `cloudmanager_orgid`, i.e. `aio config:set cloudmanager_orgid <myorgid>`
 
 ### Service Account Authentication

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "@oclif/parser": "^3.8.5",
     "@oclif/plugin-help": "^3.0.0",
     "cli-ux": "^5.4.6",
+    "figures": "^3.2.0",
     "halfred": "^2.0.0",
+    "inquirer": "^8.1.0",
     "lodash": "^4.17.15",
     "moment": "^2.29.0"
   },
@@ -92,6 +94,9 @@
       },
       "cloudmanager:program": {
         "description": "commands to work with programs"
+      },
+      "cloudmanager:org": {
+        "description": "commands to work with organizational authentication"
       }
     }
   },

--- a/src/commands/cloudmanager/org/list.js
+++ b/src/commands/cloudmanager/org/list.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Command } = require('@oclif/command')
+const { cli } = require('cli-ux')
+const figures = require('figures')
+const { getCloudManagerAuthorizedOrganizations, getOutputFormat, columnWithArray, getCloudManagerRoles, getActiveOrganizationId } = require('../../../cloudmanager-helpers')
+const commonFlags = require('../../../common-flags')
+
+class OrgListCommand extends Command {
+  async run () {
+    const { flags } = this.parse(OrgListCommand)
+
+    const organizations = await getCloudManagerAuthorizedOrganizations(flags.imsContextName)
+    const activeOrgId = await getActiveOrganizationId(flags.imsContextName)
+
+    const getOrgId = (org) => `${org.orgRef.ident}@${org.orgRef.authSrc}`
+
+    cli.table(organizations, {
+      orgId: {
+        header: 'Org Id',
+        get: getOrgId,
+      },
+      orgName: {
+        header: 'Org Name',
+      },
+      roles: columnWithArray(getCloudManagerRoles, {}, flags),
+      active: {
+        get: (org) => {
+          const orgId = getOrgId(org)
+          return orgId === activeOrgId ? figures.tick : ''
+        },
+      },
+    }, {
+      printLine: this.log,
+      output: getOutputFormat(flags),
+    })
+
+    return organizations
+  }
+}
+
+OrgListCommand.description = 'list the organizations in which the current user is authorized to use Cloud Manager'
+
+OrgListCommand.flags = {
+  ...commonFlags.global,
+  ...commonFlags.outputFormat,
+}
+
+module.exports = OrgListCommand

--- a/src/commands/cloudmanager/org/select.js
+++ b/src/commands/cloudmanager/org/select.js
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Command, flags } = require('@oclif/command')
+const { prompt } = require('inquirer')
+const { isCliAuthEnabled, getCloudManagerAuthorizedOrganizations, setCliOrgId } = require('../../../cloudmanager-helpers')
+
+class OrgSelectCommand extends Command {
+  async run () {
+    if (!isCliAuthEnabled()) {
+      this.error('This command is only intended to be used with a user token, not a service account. The org id for a service account must be provided in the service account configuration.')
+    }
+
+    const { args, flags } = this.parse(OrgSelectCommand)
+
+    const local = !flags.global
+
+    let { orgId } = args
+
+    if (!orgId) {
+      const organizations = await getCloudManagerAuthorizedOrganizations(flags.imsContextName)
+      if (organizations.length === 0) {
+        this.error('No Cloud Manager authorized organizations found.')
+      }
+
+      const answers = await prompt([
+        {
+          type: 'list',
+          name: 'orgId',
+          message: 'Select organization:',
+          choices: organizations.map(org => {
+            return {
+              name: org.orgName,
+              value: `${org.orgRef.ident}@${org.orgRef.authSrc}`,
+            }
+          }),
+        },
+      ])
+
+      orgId = answers.orgId
+    }
+    setCliOrgId(orgId, local)
+    this.log(`orgId ${orgId} set in ${local ? 'local' : 'global'} configuration`)
+
+    return orgId
+  }
+}
+
+OrgSelectCommand.description = 'select an organization in which the current user is authorized to use Cloud Manager'
+
+OrgSelectCommand.args = [
+  { name: 'orgId', required: false, description: 'the org id to store in configuration' },
+]
+
+OrgSelectCommand.flags = {
+  global: flags.boolean({ description: 'stores selected organization in global configuration' }),
+}
+
+module.exports = OrgSelectCommand

--- a/test/__mocks__/@adobe/aio-lib-ims.js
+++ b/test/__mocks__/@adobe/aio-lib-ims.js
@@ -12,6 +12,8 @@ governing permissions and limitations under the License.
 
 let currentOrgId
 
+let organizations
+
 module.exports = {
   getToken: jest.fn(ctx => 'fake-token'),
   context: {
@@ -36,5 +38,18 @@ module.exports = {
   },
   resetCurrentOrgId: () => {
     currentOrgId = undefined
+  },
+  Ims: {
+    fromToken: jest.fn((token) => {
+      return {
+        token: token,
+        ims: {
+          getOrganizations: jest.fn(() => organizations),
+        },
+      }
+    }),
+  },
+  setOrganizations: (value) => {
+    organizations = value
   },
 }

--- a/test/__mocks__/inquirer.js
+++ b/test/__mocks__/inquirer.js
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+let answers
+
+module.exports = {
+  prompt: jest.fn(() => answers),
+  setAnswers: (value) => {
+    answers = value
+  },
+}

--- a/test/commands/org/list.test.js
+++ b/test/commands/org/list.test.js
@@ -1,0 +1,121 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { cli } = require('cli-ux')
+const { setOrganizations, setCurrentOrgId, resetCurrentOrgId } = require('@adobe/aio-lib-ims')
+const { setStore } = require('@adobe/aio-lib-core-config')
+const OrgListCommand = require('../../../src/commands/cloudmanager/org/list')
+const { enableCliAuth, disableCliAuth } = require('../../../src/cloudmanager-helpers')
+
+beforeEach(() => {
+  setOrganizations([])
+  disableCliAuth()
+  resetCurrentOrgId()
+})
+
+test('org-list - cli auth', async () => {
+  setStore({
+    cloudmanager_orgid: 'abc@AdobeOrg',
+  })
+  enableCliAuth()
+  const runResult = OrgListCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await expect(runResult).resolves.toEqual([])
+
+  expect(cli.table.mock.calls[0][1].orgId.get({
+    orgName: 'myorg',
+    orgRef: {
+      ident: 'abc',
+      authSrc: 'AdobeOrg',
+    },
+  })).toEqual('abc@AdobeOrg')
+
+  expect(cli.table.mock.calls[0][1].roles.get({
+    orgName: 'myorg',
+    orgRef: {
+      ident: 'abc',
+      authSrc: 'AdobeOrg',
+    },
+  })).toEqual('')
+
+  expect(cli.table.mock.calls[0][1].roles.get({
+    orgName: 'myorg',
+    orgRef: {
+      ident: 'abc',
+      authSrc: 'AdobeOrg',
+    },
+    groups: [
+      {
+        groupDisplayName: 'CM_BUSINESS_OWNER_ROLE_PROFILE',
+      },
+      {
+        groupDisplayName: 'CM_CS_DEPLOYMENT_MANAGER_ROLE_PROFILE',
+      },
+      {
+        groupDisplayName: 'SOMETHING_ELSE',
+      },
+    ],
+  })).toEqual('Business Owner, Deployment Manager')
+
+  expect(cli.table.mock.calls[0][1].active.get({
+    orgName: 'myorg',
+    orgRef: {
+      ident: 'abc',
+      authSrc: 'AdobeOrg',
+    },
+  })).toBeTruthy()
+
+  expect(cli.table.mock.calls[0][1].active.get({
+    orgName: 'myorg',
+    orgRef: {
+      ident: 'def',
+      authSrc: 'AdobeOrg',
+    },
+  })).not.toBeTruthy()
+})
+
+test('org-list - service account auth', async () => {
+  setCurrentOrgId('abc@AdobeOrg')
+  const runResult = OrgListCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await expect(runResult).resolves.toEqual([])
+
+  expect(cli.table.mock.calls[0][1].active.get({
+    orgName: 'myorg',
+    orgRef: {
+      ident: 'abc',
+      authSrc: 'AdobeOrg',
+    },
+  })).toBeTruthy()
+
+  expect(cli.table.mock.calls[0][1].active.get({
+    orgName: 'myorg',
+    orgRef: {
+      ident: 'def',
+      authSrc: 'AdobeOrg',
+    },
+  })).not.toBeTruthy()
+})
+
+test('org-list - no org', async () => {
+  const runResult = OrgListCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toSatisfy(err => err.message === 'Unable to find IMS context aio-cli-plugin-cloudmanager')
+})
+
+test('org-list - alt context', async () => {
+  const runResult = OrgListCommand.run(['--imsContextName', 'something-else'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toSatisfy(err => err.message === 'Unable to find IMS context something-else')
+})

--- a/test/commands/org/select.test.js
+++ b/test/commands/org/select.test.js
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const Config = require('@adobe/aio-lib-core-config')
+const { setOrganizations } = require('@adobe/aio-lib-ims')
+const { prompt, setAnswers } = require('inquirer')
+const { enableCliAuth, disableCliAuth } = require('../../../src/cloudmanager-helpers')
+const OrgSelectCommand = require('../../../src/commands/cloudmanager/org/select')
+
+beforeEach(() => {
+  enableCliAuth()
+  setOrganizations([])
+})
+
+test('org-select -- nonCliMode', async () => {
+  disableCliAuth()
+
+  const runResult = OrgSelectCommand.run(['abc'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await expect(runResult).rejects.toSatisfy(err => err.message === 'This command is only intended to be used with a user token, not a service account. The org id for a service account must be provided in the service account configuration.')
+})
+
+test('org-select -- orgId arg', async () => {
+  const runResult = OrgSelectCommand.run(['abc'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await expect(runResult).resolves.toEqual('abc')
+
+  expect(Config.set.mock.calls.length).toEqual(1)
+  expect(Config.set).toBeCalledWith('cloudmanager_orgid', 'abc', true)
+})
+
+test('org-select -- orgId arg and global flag', async () => {
+  const runResult = OrgSelectCommand.run(['abc', '--global'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await expect(runResult).resolves.toEqual('abc')
+
+  expect(Config.set.mock.calls.length).toEqual(1)
+  expect(Config.set).toBeCalledWith('cloudmanager_orgid', 'abc', false)
+})
+
+test('org-select -- no organizations', async () => {
+  const runResult = OrgSelectCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await expect(runResult).rejects.toSatisfy(err => err.message === 'No Cloud Manager authorized organizations found.')
+})
+
+test('org-select -- some organizations', async () => {
+  setOrganizations([
+    {
+      orgName: 'myorg-nogroups',
+      orgRef: {
+        ident: 'abc',
+        authSrc: 'AdobeOrg',
+      },
+    },
+    {
+      orgName: 'myorg-emptygroups',
+      orgRef: {
+        ident: 'def',
+        authSrc: 'AdobeOrg',
+      },
+      groups: [],
+    },
+    {
+      orgName: 'myorg-auth',
+      orgRef: {
+        ident: 'ghi',
+        authSrc: 'AdobeOrg',
+      },
+      groups: [
+        {
+          groupDisplayName: 'CM_BUSINESS_OWNER_ROLE_PROFILE',
+        },
+      ],
+    },
+  ])
+  setAnswers({
+    orgId: 'ghi@AdobeOrg',
+  })
+
+  const runResult = OrgSelectCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await expect(runResult).resolves.toBe('ghi@AdobeOrg')
+
+  expect(Config.set.mock.calls.length).toEqual(1)
+  expect(Config.set).toBeCalledWith('cloudmanager_orgid', 'ghi@AdobeOrg', true)
+
+  expect(prompt.mock.calls.length).toEqual(1)
+  expect(prompt.mock.calls[0][0][0].choices).toEqual([
+    {
+      name: 'myorg-auth',
+      value: 'ghi@AdobeOrg',
+    },
+  ])
+})


### PR DESCRIPTION
… organizations. fixes #351

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds new commands:

* `cloudmanager:org:select` - show a list of organizations where the current user has a Cloud Manager role and enable the selection of one of them
* `cloudmanager:org:list` - render a list of organizations where the current user has a Cloud Manager role

## Related Issue

#351 

## Motivation and Context

Original browser-based documentation enabled the selection only of organizations where the user had access to I/O Developer Console.

## How Has This Been Tested?

* Unit Tests
* Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
