### PR TITLE
fix(auth): skip organization configuration check for org:select and o…

### DIFF
--- a/src/commands/cloudmanager/org/list.js
+++ b/src/commands/cloudmanager/org/list.js
@@ -55,5 +55,6 @@ OrgListCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.outputFormat,
 }
+OrgListCommand.skipOrgIdCheck = true
 
 module.exports = OrgListCommand

--- a/src/commands/cloudmanager/org/select.js
+++ b/src/commands/cloudmanager/org/select.js
@@ -65,4 +65,6 @@ OrgSelectCommand.flags = {
   global: flags.boolean({ description: 'stores selected organization in global configuration' }),
 }
 
+OrgSelectCommand.skipOrgIdCheck = true
+
 module.exports = OrgSelectCommand

--- a/src/hooks/prerun/check-ims-context-config.js
+++ b/src/hooks/prerun/check-ims-context-config.js
@@ -70,7 +70,7 @@ module.exports = function (hookOptions) {
       }
       const orgId = getCliOrgId()
       if (!orgId) {
-        this.error('cli context explicitly enabled but no org id specified. Configure using either "cloudmanager_orgid" or by running "aio console:org:select"')
+        this.error('cli context explicitly enabled but no org id specified. Configure using either "cloudmanager_orgid" or by running "aio cloudmanager:org:select"')
       }
       enableCliAuth()
     } else {
@@ -78,10 +78,18 @@ module.exports = function (hookOptions) {
     }
   } else {
     const cliConfig = Config.get(`ims.contexts.${CLI}`)
-    const orgId = getCliOrgId()
-    if (cliConfig && cliConfig.access_token && orgId) {
-      enableCliAuth()
-      return
+
+    if (hookOptions.Command.skipOrgIdCheck) {
+      if (cliConfig && cliConfig.access_token) {
+        enableCliAuth()
+        return
+      }
+    } else {
+      const orgId = getCliOrgId()
+      if (cliConfig && cliConfig.access_token && orgId) {
+        enableCliAuth()
+        return
+      }
     }
 
     checkContext(defaultContextName, true)


### PR DESCRIPTION
…rg:list. fixes #356

<!--- Provide a general summary of your changes in the Title above -->

## Description

* Add support for skipping org configuration in context check hook
* Skip org checks for org:list and org:select

## Related Issue

#356

## Motivation and Context

Enables initial org selection

## How Has This Been Tested?

* Unit tests
* Manual tests (this time with the correct scenario)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
