### PR TITLE
fix(auth): correct error message when access token exists but no org …

### DIFF
--- a/test/hooks/prerun/check-ims-context-config.test.js
+++ b/test/hooks/prerun/check-ims-context-config.test.js
@@ -25,14 +25,14 @@ const invoke = (options) => {
 }
 
 test('hook -- no config', async () => {
-  expect(invoke()).toThrowError(new Error('There is no IMS context configuration defined for ims.contexts.aio-cli-plugin-cloudmanager. Either define this context configuration or authenticate using "aio auth:login".'))
+  expect(invoke()).toThrowError(new Error('There is no IMS context configuration defined for ims.contexts.aio-cli-plugin-cloudmanager. Either define this context configuration or authenticate using "aio auth:login" and select an organization using "aio cloudmanager:org:select".'))
 })
 
 test('hook -- different flag command, custom context and no config', async () => {
   expect(invoke({
     Command: FixtureWithADifferentFlag,
     argv: [],
-  })).toThrowError(new Error('There is no IMS context configuration defined for ims.contexts.aio-cli-plugin-cloudmanager. Either define this context configuration or authenticate using "aio auth:login".'))
+  })).toThrowError(new Error('There is no IMS context configuration defined for ims.contexts.aio-cli-plugin-cloudmanager. Either define this context configuration or authenticate using "aio auth:login" and select an organization using "aio cloudmanager:org:select".'))
 })
 
 test('hook -- flag command, custom context and no config', async () => {
@@ -92,11 +92,22 @@ test('hook -- fully configured cli auth enables cli auth mode', async () => {
   expect(isCliAuthEnabled()).toBe(true)
 })
 
+test('hook -- cli auth configured without org id produces correct error message', async () => {
+  setStore({
+    'ims.contexts.cli': {
+      access_token: {
+        token: 'something',
+      },
+    },
+  })
+  expect(invoke()).toThrowError(new Error('The CLI has been authenticated, but no organization has been selected. To select an organization, run "aio cloudmanager:org:select". Alternatively, define the IMS context configuration ims.contexts.aio-cli-plugin-cloudmanager with a service account.'))
+})
+
 test('hook -- no config and skipping org command still produces error', async () => {
   expect(invoke({
     Command: FixtureWithSkippingOrgCheck,
     argv: [],
-  })).toThrowError(new Error('There is no IMS context configuration defined for ims.contexts.aio-cli-plugin-cloudmanager. Either define this context configuration or authenticate using "aio auth:login".'))
+  })).toThrowError(new Error('There is no IMS context configuration defined for ims.contexts.aio-cli-plugin-cloudmanager. Either define this context configuration or authenticate using "aio auth:login" and select an organization using "aio cloudmanager:org:select".'))
 })
 
 test('hook -- fully configured cli auth enables cli auth mode for command with skipping org', async () => {


### PR DESCRIPTION
…selected. fixes #359

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add specific error message for case where ims.contexts.cli.access_token exists, but cloudmanager_orgid does not.

## Related Issue

#359

## Motivation and Context

Improve error message

## How Has This Been Tested?

* Unit tests
* Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
