### PR TITLE
feat: require node 12 as minimum version. fixes #372

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Cloud Manager Plugin for the [Adobe I/O CLI](https://github.com/adobe/aio-cli)
 
 * [Adobe I/O CLI](https://github.com/adobe/aio-cli)
 * Node.js version compatibility:
-    * 10.x -- 10.22.0 or higher.
     * 12.x -- 12.0.0 or higher.
     * 14.x -- 14.0.0 or higher.
     * Use with odd Node versions is *not* recommended.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-cloudmanager/issues",
   "dependencies": {
-    "@adobe/aio-lib-cloudmanager": "^0.3.3",
+    "@adobe/aio-lib-cloudmanager": "^1.0.0",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-logging": "^1.2.0",
     "@adobe/aio-lib-env": "^1.1.0",
@@ -50,7 +50,7 @@
     "tmp": "0.2.1"
   },
   "engines": {
-    "node": ">=10.22.0"
+    "node": ">=12"
   },
   "files": [
     "/oclif.manifest.json",


### PR DESCRIPTION
Support for TLS 1.0 and 1.1 is being retired by Adobe in mid-July.

BREAKING CHANGE: Installation on Node 10 will now fail

<!--- Provide a general summary of your changes in the Title above -->

## Description

Node 12 is now the minimal version

## Related Issue

#372

## Motivation and Context

Ensures usage of correct node version with TLS 1.2 support

## How Has This Been Tested?

CI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
