### PR TITLE
feat(execution): add support for tailing step logs (limited to build)…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-cloudmanager/issues",
   "dependencies": {
-    "@adobe/aio-lib-cloudmanager": "^1.0.0",
+    "@adobe/aio-lib-cloudmanager": "^1.1.1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-logging": "^1.2.0",
     "@adobe/aio-lib-env": "^1.1.0",

--- a/src/commands/cloudmanager/execution/tail-step-log.js
+++ b/src/commands/cloudmanager/execution/tail-step-log.js
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Command } = require('@oclif/command')
+const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
+const commonFlags = require('../../../common-flags')
+
+class TailExecutionStepLog extends Command {
+  async run () {
+    const { args, flags } = this.parse(TailExecutionStepLog)
+
+    const programId = getProgramId(flags)
+
+    let result
+
+    try {
+      result = await this.tailExecutionStepLog(programId, args.pipelineId, args.action, flags.file, flags.imsContextName)
+    } catch (error) {
+      this.error(error.message)
+    }
+
+    this.log()
+
+    return result
+  }
+
+  async tailExecutionStepLog (programId, pipelineId, action, logFile, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.tailExecutionStepLog(programId, pipelineId, action, logFile, process.stdout)
+  }
+}
+
+TailExecutionStepLog.description = 'tail step log'
+
+TailExecutionStepLog.flags = {
+  ...commonFlags.global,
+  ...commonFlags.programId,
+}
+
+TailExecutionStepLog.args = [
+  { name: 'pipelineId', required: true, description: 'the pipeline id' },
+  {
+    name: 'action',
+    required: true,
+    description: 'the step action',
+    default: 'build',
+    options: [
+      'build',
+    ],
+  },
+]
+
+module.exports = TailExecutionStepLog

--- a/test/__mocks__/@adobe/aio-lib-cloudmanager.js
+++ b/test/__mocks__/@adobe/aio-lib-cloudmanager.js
@@ -110,6 +110,7 @@ function createDefaultMock () {
     deleteProgram: jest.fn(() => Promise.resolve()),
     deleteEnvironment: jest.fn(() => Promise.resolve()),
     tailLog: jest.fn(() => Promise.resolve()),
+    tailExecutionStepLog: jest.fn(() => Promise.resolve()),
   }
 }
 

--- a/test/commands/execution/tail-step-log.test.js
+++ b/test/commands/execution/tail-step-log.test.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
+const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const TailExecutionStepLog = require('../../../src/commands/cloudmanager/execution/tail-step-log')
+
+beforeEach(() => {
+  resetCurrentOrgId()
+})
+
+test('tail-execution-step-log - missing arg', async () => {
+  expect.assertions(2)
+
+  const runResult = TailExecutionStepLog.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+})
+
+test('tail-execution-step-log - missing config', async () => {
+  expect.assertions(2)
+
+  const runResult = TailExecutionStepLog.run(['5', '--programId', '7'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toEqual(new Error('Unable to find IMS context aio-cli-plugin-cloudmanager'))
+})
+
+test('tail-execution-step-log - stdout', async () => {
+  setCurrentOrgId('good')
+
+  expect.assertions(5)
+
+  const runResult = TailExecutionStepLog.run(['15', '--programId', '5'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+
+  await runResult
+  await expect(init.mock.calls.length).toEqual(1)
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(mockSdk.tailExecutionStepLog.mock.calls.length).toEqual(1)
+  await expect(mockSdk.tailExecutionStepLog).toHaveBeenCalledWith('5', '15', 'build', undefined, process.stdout)
+})


### PR DESCRIPTION
…. fixes #377

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `aio cloudmanager:execution:tail-step-log` command

## Related Issue

#377 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit test
Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
