### PR TITLE
Add Base Commerce Command

### DIFF
--- a/src/base-commerce-cli-command.js
+++ b/src/base-commerce-cli-command.js
@@ -13,8 +13,10 @@ governing permissions and limitations under the License.
 const { Command } = require('@oclif/command')
 const { cli } = require('cli-ux')
 const { initSdk } = require('./cloudmanager-helpers')
-class BaseCommerceCommand extends Command {
+class BaseCommerceCliCommand extends Command {
   async runSync (programId, environmentId, body, pollingInterval, command, imsContextName = null) {
+    this.warn('Commerce cli commands are in active development and may not be functional.')
+
     const sdk = await initSdk(imsContextName)
     const commandMessage = `Starting ${command}`
     cli.action.start(commandMessage)
@@ -42,4 +44,4 @@ class BaseCommerceCommand extends Command {
   }
 }
 
-module.exports = BaseCommerceCommand
+module.exports = BaseCommerceCliCommand

--- a/src/base-commerce-command.js
+++ b/src/base-commerce-command.js
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Command } = require('@oclif/command')
+const { cli } = require('cli-ux')
+const { initSdk } = require('./cloudmanager-helpers')
+class BaseCommerceCommand extends Command {
+  async runSync (programId, environmentId, body, pollingInterval, command, imsContextName = null) {
+    const sdk = await initSdk(imsContextName)
+    const commandMessage = `Starting ${command}`
+    cli.action.start(commandMessage)
+    const { id: commandId } = await sdk.postCLICommand(programId, environmentId, body)
+    let result = await this.callGet(sdk, programId, environmentId, commandId, command)
+
+    while (result.status === 'RUNNING' || result.status === 'CREATING') {
+      await cli.wait(pollingInterval)
+      result = await this.callGet(sdk, programId, environmentId, commandId, command)
+    }
+    cli.action.start(`${this.formatStatus(result.status)} ${command}`)
+    cli.action.stop(result.message)
+    return result
+  }
+
+  async callGet (sdk, programId, environmentId, commandId, command) {
+    const getResponse = await sdk.getCLICommand(programId, environmentId, commandId)
+    const result = await getResponse
+    cli.action.start(`${this.formatStatus(result.status)} ${command}`)
+    return result
+  }
+
+  formatStatus (status) {
+    return status === 'CREATING' ? 'Starting' : status[0].toUpperCase() + status.slice(1).toLowerCase()
+  }
+}
+
+module.exports = BaseCommerceCommand

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
@@ -10,12 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const BaseCommerceCommand = require('../../../../../base-commerce-command')
+const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
 const { getProgramId } = require('../../../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const commonFlags = require('../../../../../common-flags')
 
-class MaintenanceStatusCommand extends BaseCommerceCommand {
+class MaintenanceStatusCommand extends BaseCommerceCliCommand {
   async run () {
     const { args, flags } = this.parse(MaintenanceStatusCommand)
 
@@ -51,7 +51,7 @@ MaintenanceStatusCommand.args = [
 ]
 
 MaintenanceStatusCommand.aliases = [
-  'cloudmanager:magento:maintenance-status',
+  'cloudmanager:commerce:maintenance-status',
 ]
 
 module.exports = MaintenanceStatusCommand

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const BaseCommerceCommand = require('../../../../../base-commerce-command')
+const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const { cli } = require('cli-ux')
+const commonFlags = require('../../../../../common-flags')
+
+class MaintenanceStatusCommand extends BaseCommerceCommand {
+  async run () {
+    const { args, flags } = this.parse(MaintenanceStatusCommand)
+
+    const programId = getProgramId(flags)
+
+    let result
+
+    try {
+      result = await this.runSync(programId, args.environmentId,
+        {
+          type: 'bin/magento',
+          command: 'maintenance:status',
+        },
+        1000, 'maintenance:status')
+    } catch (error) {
+      cli.action.stop(error.message)
+      return
+    }
+
+    return result
+  }
+}
+
+MaintenanceStatusCommand.description = 'commerce maintenance status'
+
+MaintenanceStatusCommand.flags = {
+  ...commonFlags.global,
+  ...commonFlags.programId,
+}
+
+MaintenanceStatusCommand.args = [
+  { name: 'environmentId', required: true, description: 'the environment id' },
+]
+
+MaintenanceStatusCommand.aliases = [
+  'cloudmanager:magento:maintenance-status',
+]
+
+module.exports = MaintenanceStatusCommand

--- a/test/__mocks__/cli-ux.js
+++ b/test/__mocks__/cli-ux.js
@@ -19,5 +19,6 @@ module.exports = {
     },
     info: jest.fn(),
     open: jest.fn(),
+    wait: jest.fn(),
   },
 }

--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { cli } = require('cli-ux')
+const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
+const MaintenanceStatusCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/status')
+
+beforeEach(() => {
+  resetCurrentOrgId()
+})
+
+test('maintenance:status - missing arg', async () => {
+  expect.assertions(2)
+
+  const runResult = MaintenanceStatusCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toSatisfy(
+    (err) => err.message.indexOf('Missing 1 required arg') === 0,
+  )
+})
+
+test('maintenance:status - missing config', async () => {
+  expect.assertions(3)
+
+  const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).resolves.toEqual(undefined)
+  await expect(cli.action.stop.mock.calls[0][0]).toBe(
+    'Unable to find IMS context aio-cli-plugin-cloudmanager',
+  )
+})
+
+test('maintenance:status', async () => {
+  let counter = 0
+  setCurrentOrgId('good')
+  mockSdk.postCLICommand = jest.fn(() =>
+    Promise.resolve({
+      id: '5000',
+    }),
+  )
+  mockSdk.getCLICommand = jest.fn(() => {
+    counter++
+    return counter < 3
+      ? Promise.resolve({
+        status: 'RUNNING',
+        message: 'running maintenance status',
+      })
+      : Promise.resolve({
+        status: 'COMPLETE',
+        message: 'maintenance enabled',
+      })
+  })
+
+  expect.assertions(8)
+
+  const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await runResult
+  await expect(init.mock.calls.length).toEqual(1)
+  await expect(init).toHaveBeenCalledWith(
+    'good',
+    'test-client-id',
+    'fake-token',
+    'https://cloudmanager.adobe.io',
+  )
+  await expect(mockSdk.postCLICommand.mock.calls.length).toEqual(1)
+  await expect(mockSdk.postCLICommand).toHaveBeenCalledWith('5', '10', {
+    type: 'bin/magento',
+    command: 'maintenance:status',
+  })
+  await expect(mockSdk.getCLICommand).toHaveBeenCalledWith('5', '10', '5000')
+  await expect(mockSdk.getCLICommand).toHaveBeenCalledTimes(3)
+  await expect(cli.action.stop.mock.calls[0][0]).toEqual('maintenance enabled')
+})
+
+test('maintenance:status - api error', async () => {
+  setCurrentOrgId('good')
+  mockSdk.postCLICommand = jest.fn(() =>
+    Promise.reject(new Error('Command failed.')),
+  )
+  mockSdk.getCLICommand = jest.fn()
+  const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await runResult
+  await expect(cli.action.stop.mock.calls[0][0]).toEqual('Command failed.')
+})


### PR DESCRIPTION
## Description

This will add the base class for all Commerce commands. The class encapsulates the logic of calling the POST endpoint to initiate the command and then poll the get endpoint while the command is running.

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/383

## Motivation and Context

Commerce CLI commands need to be integrated into the Cloud Manager Plugin as the Cloud Manager API will soon have commands for running CLI commands on Cloud Manager hosted Commerce programs.

## How Has This Been Tested?

I have added the simplest command maintenance:status in my development environment that extends this base class. I wrote unit tests that match the unit tests in the app. All of the unit tests pass.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<img width="1049" alt="Screen Shot 2021-07-14 at 3 47 58 PM" src="https://user-images.githubusercontent.com/1539057/125691097-2ac378dc-e161-44ee-9212-051f6d419ae7.png">


- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
