### PR TITLE
fix(execution): code quality step startedAt should only be overridden…

### DIFF
--- a/src/commands/cloudmanager/execution/get-step-details.js
+++ b/src/commands/cloudmanager/execution/get-step-details.js
@@ -37,7 +37,9 @@ class GetExecutionStepDetails extends Command {
 
       const buildStep = stepStates.find(stepState => stepState.action === 'build')
       const codeQualityStep = stepStates.find(stepState => stepState.action === 'codeQuality')
-      codeQualityStep.startedAt = buildStep.finishedAt
+      if (buildStep.status === 'FINISHED') {
+        codeQualityStep.startedAt = buildStep.finishedAt
+      }
 
       cli.table(stepStates, {
         action: {

--- a/test/data/execution1011.json
+++ b/test/data/execution1011.json
@@ -1,0 +1,74 @@
+{
+  "_embedded": {
+    "stepStates": [
+      {
+        "id": "2266443",
+        "stepId": "1001998",
+        "phaseId": "568199",
+        "executionId": "5",
+        "pipelineId": "4",
+        "programId": "5",
+        "action": "validate",
+        "startedAt": "2021-04-07T14:09:25.655+0000",
+        "finishedAt": "2021-04-07T14:09:32.273+0000",
+        "updatedAt": "2021-04-07T14:09:32.493+0000",
+        "status": "FINISHED"
+      },
+      {
+        "id": "2266444",
+        "stepId": "1001999",
+        "phaseId": "568200",
+        "executionId": "5",
+        "pipelineId": "4",
+        "programId": "5",
+        "action": "build",
+        "repository": "XXX",
+        "branch": "dev",
+        "startedAt": "2021-04-07T14:09:34.464+0000",
+        "finishedAt": "2021-04-07T14:10:42.448+0000",
+        "updatedAt": "2021-04-07T14:10:42.936+0000",
+        "status": "CANCELLED",
+        "statusString": "Pipeline execution cancelled"
+      },
+      {
+        "id": "2266445",
+        "stepId": "1002000",
+        "phaseId": "568200",
+        "executionId": "5",
+        "pipelineId": "4",
+        "programId": "5",
+        "action": "codeQuality",
+        "repository": "XXX",
+        "branch": "dev",
+        "updatedAt": "2021-04-07T14:09:18.875+0000",
+        "status": "NOT_STARTED"
+      },
+      {
+        "id": "2266446",
+        "stepId": "1002001",
+        "phaseId": "568201",
+        "executionId": "5",
+        "pipelineId": "4",
+        "programId": "5",
+        "action": "buildImage",
+        "updatedAt": "2021-04-07T14:09:18.875+0000",
+        "status": "NOT_STARTED",
+        "aemReleaseVersion": "2021.03.5026.1615324047792"
+      },
+      {
+        "id": "2266447",
+        "stepId": "1002052",
+        "phaseId": "568252",
+        "executionId": "5",
+        "pipelineId": "4",
+        "programId": "5",
+        "action": "deploy",
+        "environment": "YYY",
+        "environmentType": "dev",
+        "environmentId": "9",
+        "updatedAt": "2021-04-07T14:09:18.875+0000",
+        "status": "NOT_STARTED"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
… if build finished. fixes #388

<!--- Provide a general summary of your changes in the Title above -->

## Description

Only override the undefined codeQualityStep.startedAt if the build step finished

## Related Issue

#388 

## Motivation and Context

Bug fix

## How Has This Been Tested?

* Unit test
* Manual test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
