### PR TITLE
fix(commerce): add descriptions. fixes#396

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,15 @@
       },
       "cloudmanager:org": {
         "description": "commands to work with organizational authentication"
+      },
+      "cloudmanager:commerce": {
+        "description": "commands to work with commerce cli"
+      },
+      "cloudmanager:commerce:bin-magento": {
+        "description": "commands to work with bin-magento for commerce cli"
+      },
+      "cloudmanager:commerce:bin-magento:maintenance": {
+        "description": "commands to work with maintenance for bin-magento"
       }
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cloud Manager does not show descriptions for the nested commerce commands

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/396

## Motivation and Context

This will show descriptions for each part of the Commerce CLI commands.

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
