### PR TITLE
feat(commerce): update method names. fixes#404

### DIFF
--- a/src/base-commerce-cli-command.js
+++ b/src/base-commerce-cli-command.js
@@ -20,7 +20,7 @@ class BaseCommerceCliCommand extends Command {
     const sdk = await initSdk(imsContextName)
     const commandMessage = `Starting ${command}`
     cli.action.start(commandMessage)
-    const { id: commandId } = await sdk.postCLICommand(programId, environmentId, body)
+    const { id: commandId } = await sdk.postCommerceCommandExecution(programId, environmentId, body)
     let result = await this.callGet(sdk, programId, environmentId, commandId, command)
 
     while (result.status === 'RUNNING' || result.status === 'CREATING') {
@@ -33,7 +33,7 @@ class BaseCommerceCliCommand extends Command {
   }
 
   async callGet (sdk, programId, environmentId, commandId, command) {
-    const getResponse = await sdk.getCLICommand(programId, environmentId, commandId)
+    const getResponse = await sdk.getCommerceCommandExecution(programId, environmentId, commandId)
     const result = await getResponse
     cli.action.start(`${this.formatStatus(result.status)} ${command}`)
     return result

--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -43,12 +43,12 @@ test('maintenance:status - missing config', async () => {
 test('maintenance:status', async () => {
   let counter = 0
   setCurrentOrgId('good')
-  mockSdk.postCLICommand = jest.fn(() =>
+  mockSdk.postCommerceCommandExecution = jest.fn(() =>
     Promise.resolve({
       id: '5000',
     }),
   )
-  mockSdk.getCLICommand = jest.fn(() => {
+  mockSdk.getCommerceCommandExecution = jest.fn(() => {
     counter++
     return counter < 3
       ? Promise.resolve({
@@ -73,22 +73,22 @@ test('maintenance:status', async () => {
     'fake-token',
     'https://cloudmanager.adobe.io',
   )
-  await expect(mockSdk.postCLICommand.mock.calls.length).toEqual(1)
-  await expect(mockSdk.postCLICommand).toHaveBeenCalledWith('5', '10', {
+  await expect(mockSdk.postCommerceCommandExecution.mock.calls.length).toEqual(1)
+  await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'maintenance:status',
   })
-  await expect(mockSdk.getCLICommand).toHaveBeenCalledWith('5', '10', '5000')
-  await expect(mockSdk.getCLICommand).toHaveBeenCalledTimes(3)
+  await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
+  await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
   await expect(cli.action.stop.mock.calls[0][0]).toEqual('maintenance enabled')
 })
 
 test('maintenance:status - api error', async () => {
   setCurrentOrgId('good')
-  mockSdk.postCLICommand = jest.fn(() =>
+  mockSdk.postCommerceCommandExecution = jest.fn(() =>
     Promise.reject(new Error('Command failed.')),
   )
-  mockSdk.getCLICommand = jest.fn()
+  mockSdk.getCommerceCommandExecution = jest.fn()
   const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult


### PR DESCRIPTION
This PR will update the methods in BaseCommerceCommand from getCLICommand and postCLICommand to getCommerceCommandExecution and postCommerceCommandExecution.

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/404

## Motivation and Context

Fixes the names of the methods to match what will be in the lib

## How Has This Been Tested?

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
