### PR TITLE
Update RUNNING status to PENDING in base-commerce-cli-comman d

### DIFF
--- a/src/base-commerce-cli-command.js
+++ b/src/base-commerce-cli-command.js
@@ -23,7 +23,7 @@ class BaseCommerceCliCommand extends Command {
     const { id: commandId } = await sdk.postCommerceCommandExecution(programId, environmentId, body)
     let result = await this.callGet(sdk, programId, environmentId, commandId, command)
 
-    while (result.status === 'RUNNING' || result.status === 'CREATING') {
+    while (result.status === 'RUNNING' || result.status === 'PENDING') {
       await cli.wait(pollingInterval)
       result = await this.callGet(sdk, programId, environmentId, commandId, command)
     }

--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -50,15 +50,21 @@ test('maintenance:status', async () => {
   )
   mockSdk.getCommerceCommandExecution = jest.fn(() => {
     counter++
-    return counter < 3
-      ? Promise.resolve({
+    if (counter === 1) {
+      return Promise.resolve({
+        status: 'PENDING',
+        message: 'running maintenance status',
+      })
+    } else if (counter < 3) {
+      return Promise.resolve({
         status: 'RUNNING',
         message: 'running maintenance status',
       })
-      : Promise.resolve({
-        status: 'COMPLETE',
-        message: 'maintenance enabled',
-      })
+    }
+    return Promise.resolve({
+      status: 'COMPLETE',
+      message: 'maintenance enabled',
+    })
   })
 
   expect.assertions(8)


### PR DESCRIPTION
Currently, the status that base commerce cli command will poll the GET endpoint for a command is "RUNNING" and "CREATING." The API team changed the "CREATING" status to "PENDING." The file should be updated to reflect that change.

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/409

## How Has This Been Tested?

Unit tests


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
