### PR TITLE
fix(commerce): change status to pending. fixes#411

### DIFF
--- a/src/base-commerce-cli-command.js
+++ b/src/base-commerce-cli-command.js
@@ -40,7 +40,7 @@ class BaseCommerceCliCommand extends Command {
   }
 
   formatStatus (status) {
-    return status === 'CREATING' ? 'Starting' : status[0].toUpperCase() + status.slice(1).toLowerCase()
+    return status === 'PENDING' ? 'Starting' : status[0].toUpperCase() + status.slice(1).toLowerCase()
   }
 }
 

--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -67,7 +67,7 @@ test('maintenance:status', async () => {
     })
   })
 
-  expect.assertions(8)
+  expect.assertions(11)
 
   const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -86,6 +86,9 @@ test('maintenance:status', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
+  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting maintenance:status')
+  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting maintenance:status')
+  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running maintenance:status')
   await expect(cli.action.stop.mock.calls[0][0]).toEqual('maintenance enabled')
 })
 


### PR DESCRIPTION
The status should be PENDING in the formatStatus method. The status is CREATING in the formatStatus method.

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/411

Unit Tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
