### PR TITLE
chore(test): remove unnecessary usage of toSatisfy

### DIFF
--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -24,9 +24,7 @@ test('maintenance:status - missing arg', async () => {
 
   const runResult = MaintenanceStatusCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(
-    (err) => err.message.indexOf('Missing 1 required arg') === 0,
-  )
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('maintenance:status - missing config', async () => {
@@ -34,7 +32,7 @@ test('maintenance:status - missing config', async () => {
 
   const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('maintenance:status', async () => {

--- a/test/commands/current-execution/advance.test.js
+++ b/test/commands/current-execution/advance.test.js
@@ -23,7 +23,7 @@ test('advance-current-execution - missing arg', async () => {
 
   const runResult = AdvanceCurrentExecution.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('advance-current-execution - missing config', async () => {
@@ -31,7 +31,7 @@ test('advance-current-execution - missing config', async () => {
 
   const runResult = AdvanceCurrentExecution.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('advance-current-execution - configured', async () => {

--- a/test/commands/current-execution/cancel.test.js
+++ b/test/commands/current-execution/cancel.test.js
@@ -23,7 +23,7 @@ test('cancel-current-execution - missing arg', async () => {
 
   const runResult = CancelCurrentExecution.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('cancel-current-execution - missing config', async () => {
@@ -31,7 +31,7 @@ test('cancel-current-execution - missing config', async () => {
 
   const runResult = CancelCurrentExecution.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('cancel-current-execution - configured', async () => {

--- a/test/commands/current-execution/get.test.js
+++ b/test/commands/current-execution/get.test.js
@@ -25,14 +25,14 @@ test('get-current-execution - missing arg', async () => {
 
   const runResult = GetCurrentExecution.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('get-current-execution - missing config', async () => {
   expect.assertions(1)
 
   const runResult = GetCurrentExecution.run(['5', '--programId', '5'])
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('get-current-execution - configured', async () => {

--- a/test/commands/environment/delete.test.js
+++ b/test/commands/environment/delete.test.js
@@ -23,7 +23,7 @@ test('delete-environment - missing arg', async () => {
 
   const runResult = DeleteEnvironmentCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('delete-environment - missing config', async () => {
@@ -31,7 +31,7 @@ test('delete-environment - missing config', async () => {
 
   const runResult = DeleteEnvironmentCommand.run(['--programId', '4', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('delete-environment - configured', async () => {

--- a/test/commands/environment/download-logs.test.js
+++ b/test/commands/environment/download-logs.test.js
@@ -25,14 +25,14 @@ test('download-logs - missing arg', async () => {
 
   const runResult = DownloadLogs.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 3 required args') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 3 required args/)
 })
 
 test('download-logs - missing config', async () => {
   expect.assertions(1)
 
   const runResult = DownloadLogs.run(['5', 'author', 'aemerror', '--programId', '5'])
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('download-logs - success single', async () => {

--- a/test/commands/environment/list-available-log-options.test.js
+++ b/test/commands/environment/list-available-log-options.test.js
@@ -25,7 +25,7 @@ test('list-available-logs - missing arg', async () => {
 
   const runResult = ListAvailableLogOptionsCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') > -1)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('list-available-logs - missing programId', async () => {
@@ -33,14 +33,14 @@ test('list-available-logs - missing programId', async () => {
 
   const runResult = ListAvailableLogOptionsCommand.run(['1'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('list-available-logs - missing config', async () => {
   expect.assertions(1)
 
   const runResult = ListAvailableLogOptionsCommand.run(['1', '--programId', '5'])
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('list-available-logs - empty', async () => {

--- a/test/commands/environment/list-variables.test.js
+++ b/test/commands/environment/list-variables.test.js
@@ -25,7 +25,7 @@ test('list-environment-variables - missing arg', async () => {
 
   const runResult = ListEnvironmentVariablesCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') > -1)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('list-environment-variables - missing programId', async () => {
@@ -33,7 +33,7 @@ test('list-environment-variables - missing programId', async () => {
 
   const runResult = ListEnvironmentVariablesCommand.run(['1'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('list-environment-variables - missing config', async () => {
@@ -41,7 +41,7 @@ test('list-environment-variables - missing config', async () => {
 
   const runResult = ListEnvironmentVariablesCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('list-environment-variables - success', async () => {

--- a/test/commands/environment/open-developer-console.test.js
+++ b/test/commands/environment/open-developer-console.test.js
@@ -25,7 +25,7 @@ test('open-developer-console - missing arg', async () => {
 
   const runResult = OpenDeveloperConsoleCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') > -1)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('open-developer-console - missing programId', async () => {
@@ -33,7 +33,7 @@ test('open-developer-console - missing programId', async () => {
 
   const runResult = OpenDeveloperConsoleCommand.run(['1'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('open-developer-console - missing config', async () => {
@@ -41,7 +41,7 @@ test('open-developer-console - missing config', async () => {
 
   const runResult = OpenDeveloperConsoleCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('open-developer-console - success', async () => {

--- a/test/commands/environment/set-variables.test.js
+++ b/test/commands/environment/set-variables.test.js
@@ -52,7 +52,7 @@ test('set-environment-variables - missing arg', async () => {
 
   const runResult = SetEnvironmentVariablesCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') > -1)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('set-environment-variables - missing programId', async () => {
@@ -60,7 +60,7 @@ test('set-environment-variables - missing programId', async () => {
 
   const runResult = SetEnvironmentVariablesCommand.run(['1'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('set-environment-variables - missing config', async () => {
@@ -68,7 +68,7 @@ test('set-environment-variables - missing config', async () => {
 
   const runResult = SetEnvironmentVariablesCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('set-environment-variables - bad variable flag', async () => {
@@ -81,7 +81,7 @@ test('set-environment-variables - bad variable flag', async () => {
 
   const runResult = SetEnvironmentVariablesCommand.run(['1', '--variable', 'foo'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
 })
 
 test('set-environment-variables - bad secret flag', async () => {
@@ -94,7 +94,7 @@ test('set-environment-variables - bad secret flag', async () => {
 
   const runResult = SetEnvironmentVariablesCommand.run(['1', '--secret', 'foo'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
 })
 
 test('set-environment-variables - config', async () => {
@@ -722,7 +722,7 @@ test('set-environment-variables - internal name strict mode on via flag', async 
   const runResult = SetEnvironmentVariablesCommand.run(['1', '--variable', 'INTERNAL_foo', 'bar', '--strict'])
   await expect(runResult instanceof Promise).toBeTruthy()
 
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:INTERNAL_VARIABLE_USAGE] The variable name INTERNAL_foo is reserved for internal usage and will be ignored.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:INTERNAL_VARIABLE_USAGE] The variable name INTERNAL_foo is reserved for internal usage and will be ignored.')
 })
 
 test('set-environment-variables - internal name strict mode on via config', async () => {
@@ -737,5 +737,5 @@ test('set-environment-variables - internal name strict mode on via config', asyn
   const runResult = SetEnvironmentVariablesCommand.run(['1', '--variable', 'INTERNAL_foo', 'bar'])
   await expect(runResult instanceof Promise).toBeTruthy()
 
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:INTERNAL_VARIABLE_USAGE] The variable name INTERNAL_foo is reserved for internal usage and will be ignored.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:INTERNAL_VARIABLE_USAGE] The variable name INTERNAL_foo is reserved for internal usage and will be ignored.')
 })

--- a/test/commands/environment/tail-log.test.js
+++ b/test/commands/environment/tail-log.test.js
@@ -23,7 +23,7 @@ test('tail-log - missing arg', async () => {
 
   const runResult = TailLog.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 3 required args') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 3 required arg/)
 })
 
 test('tail-log - missing config', async () => {
@@ -31,7 +31,7 @@ test('tail-log - missing config', async () => {
 
   const runResult = TailLog.run(['5', 'author', 'aemerror', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('tail-log - config', async () => {

--- a/test/commands/execution/get-quality-gate-results.test.js
+++ b/test/commands/execution/get-quality-gate-results.test.js
@@ -27,7 +27,7 @@ test('get-quality-gate-results - missing arg', async () => {
 
   const runResult = GetQualityGateResults.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 3 required args') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 3 required args/)
 })
 
 test('get-quality-gate-results - missing config', async () => {
@@ -35,7 +35,7 @@ test('get-quality-gate-results - missing config', async () => {
 
   const runResult = GetQualityGateResults.run(['5', '--programId', '7', '1001', 'codeQuality'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('get-quality-gate-results - happy path', async () => {

--- a/test/commands/execution/get-step-details.test.js
+++ b/test/commands/execution/get-step-details.test.js
@@ -26,7 +26,7 @@ test('get-execution-step-details - missing arg', async () => {
 
   const runResult = GetExecutionStepDetails.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 2 required args') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 2 required args/)
 })
 
 test('get-execution-step-details - missing config', async () => {
@@ -34,7 +34,7 @@ test('get-execution-step-details - missing config', async () => {
 
   const runResult = GetExecutionStepDetails.run(['5', '--programId', '7', '1001'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('get-execution-step-details - no result', async () => {

--- a/test/commands/execution/get-step-log.test.js
+++ b/test/commands/execution/get-step-log.test.js
@@ -25,7 +25,7 @@ test('get-execution-step-log - missing arg', async () => {
 
   const runResult = GetExecutionStepLog.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 3 required args') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 3 required arg/)
 })
 
 test('get-execution-step-log - missing config', async () => {
@@ -33,7 +33,7 @@ test('get-execution-step-log - missing config', async () => {
 
   const runResult = GetExecutionStepLog.run(['5', '--programId', '7', '1001', 'codeQuality'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('get-execution-step-log - stdout', async () => {

--- a/test/commands/execution/tail-step-log.test.js
+++ b/test/commands/execution/tail-step-log.test.js
@@ -23,7 +23,7 @@ test('tail-execution-step-log - missing arg', async () => {
 
   const runResult = TailExecutionStepLog.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('tail-execution-step-log - missing config', async () => {
@@ -31,7 +31,7 @@ test('tail-execution-step-log - missing config', async () => {
 
   const runResult = TailExecutionStepLog.run(['5', '--programId', '7'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('tail-execution-step-log - stdout', async () => {

--- a/test/commands/list-programs.test.js
+++ b/test/commands/list-programs.test.js
@@ -23,7 +23,7 @@ test('list-programs - missing config', async () => {
 
   const runResult = ListProgramsCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
   expect(init.mock.calls.length).toEqual(0)
 })
 

--- a/test/commands/org/list.test.js
+++ b/test/commands/org/list.test.js
@@ -112,11 +112,11 @@ test('org-list - service account auth', async () => {
 test('org-list - no org', async () => {
   const runResult = OrgListCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('org-list - alt context', async () => {
   const runResult = OrgListCommand.run(['--imsContextName', 'something-else'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context something-else.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context something-else.')
 })

--- a/test/commands/org/select.test.js
+++ b/test/commands/org/select.test.js
@@ -28,7 +28,7 @@ test('org-select -- nonCliMode', async () => {
   const runResult = OrgSelectCommand.run(['abc'])
   await expect(runResult instanceof Promise).toBeTruthy()
 
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:CLI_ONLY_COMMAND] This command is only intended to be used with a user token, not a service account. The org id for a service account must be provided in the service account configuration.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:CLI_ONLY_COMMAND] This command is only intended to be used with a user token, not a service account. The org id for a service account must be provided in the service account configuration.')
 })
 
 test('org-select -- orgId arg', async () => {
@@ -55,7 +55,7 @@ test('org-select -- no organizations', async () => {
   const runResult = OrgSelectCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
 
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_CM_ORGS] No Cloud Manager authorized organizations found.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_CM_ORGS] No Cloud Manager authorized organizations found.')
 })
 
 test('org-select -- some organizations', async () => {

--- a/test/commands/pipeline/create-execution.test.js
+++ b/test/commands/pipeline/create-execution.test.js
@@ -24,7 +24,7 @@ test('start-execution - missing arg', async () => {
 
   const runResult = StartExecutionCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('start-execution - missing config', async () => {
@@ -32,7 +32,7 @@ test('start-execution - missing config', async () => {
 
   const runResult = StartExecutionCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('start-execution - some url', async () => {

--- a/test/commands/pipeline/delete.test.js
+++ b/test/commands/pipeline/delete.test.js
@@ -23,7 +23,7 @@ test('delete-pipeline - missing arg', async () => {
 
   const runResult = DeletePipelineCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('delete-pipeline - missing config', async () => {
@@ -31,7 +31,7 @@ test('delete-pipeline - missing config', async () => {
 
   const runResult = DeletePipelineCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('delete-pipeline - configured', async () => {

--- a/test/commands/pipeline/list-executions.test.js
+++ b/test/commands/pipeline/list-executions.test.js
@@ -24,7 +24,7 @@ test('list-execution - missing arg', async () => {
 
   const runResult = ListExecutionsCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('list-execution - missing config', async () => {

--- a/test/commands/pipeline/list-variables.test.js
+++ b/test/commands/pipeline/list-variables.test.js
@@ -25,7 +25,7 @@ test('list-pipeline-variables - missing arg', async () => {
 
   const runResult = ListPipelineVariablesCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') > -1)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('list-pipeline-variables - missing programId', async () => {
@@ -33,7 +33,7 @@ test('list-pipeline-variables - missing programId', async () => {
 
   const runResult = ListPipelineVariablesCommand.run(['1'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('list-pipeline-variables - missing config', async () => {
@@ -41,7 +41,7 @@ test('list-pipeline-variables - missing config', async () => {
 
   const runResult = ListPipelineVariablesCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('list-pipeline-variables - success', async () => {

--- a/test/commands/pipeline/set-variables.test.js
+++ b/test/commands/pipeline/set-variables.test.js
@@ -24,7 +24,7 @@ test('set-pipeline-variables - missing arg', async () => {
 
   const runResult = SetPipelineVariablesCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') > -1)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('set-pipeline-variables - missing programId', async () => {
@@ -32,7 +32,7 @@ test('set-pipeline-variables - missing programId', async () => {
 
   const runResult = SetPipelineVariablesCommand.run(['1'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('set-pipeline-variables - missing config', async () => {
@@ -40,7 +40,7 @@ test('set-pipeline-variables - missing config', async () => {
 
   const runResult = SetPipelineVariablesCommand.run(['1', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('set-pipeline-variables - bad variable flag', async () => {
@@ -53,7 +53,7 @@ test('set-pipeline-variables - bad variable flag', async () => {
 
   const runResult = SetPipelineVariablesCommand.run(['8', '--variable', 'foo'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
 })
 
 test('set-pipeline-variables - empty variable flag', async () => {
@@ -66,7 +66,7 @@ test('set-pipeline-variables - empty variable flag', async () => {
 
   const runResult = SetPipelineVariablesCommand.run(['8', '--variable', 'foo', ''])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:BLANK_VARIABLE_VALUE] Blank variable values are not allowed. Use the proper flag if you intend to delete a variable.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:BLANK_VARIABLE_VALUE] Blank variable values are not allowed. Use the proper flag if you intend to delete a variable.')
 })
 
 test('set-pipeline-variables - bad secret flag', async () => {
@@ -79,7 +79,7 @@ test('set-pipeline-variables - bad secret flag', async () => {
 
   const runResult = SetPipelineVariablesCommand.run(['8', '--secret', 'foo'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MALFORMED_NAME_VALUE_PAIR] Please provide correct values for flags')
 })
 test('set-pipeline-variables - config', async () => {
   setCurrentOrgId('good')

--- a/test/commands/pipeline/update.test.js
+++ b/test/commands/pipeline/update.test.js
@@ -24,7 +24,7 @@ test('update-pipeline - missing arg', async () => {
 
   const runResult = UpdatePipelineCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('update-pipeline - missing config', async () => {
@@ -32,7 +32,7 @@ test('update-pipeline - missing config', async () => {
 
   const runResult = UpdatePipelineCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('update-pipeline - branch success', async () => {
@@ -83,7 +83,7 @@ test('update-pipeline - both tag and branch', async () => {
 
   const runResult = UpdatePipelineCommand.run(['--programId', '5', '5', '--branch', 'develop', '--tag', 'foo'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:BOTH_BRANCH_AND_TAG_PROVIDED] Both branch and tag cannot be specified.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:BOTH_BRANCH_AND_TAG_PROVIDED] Both branch and tag cannot be specified.')
 })
 
 test('update-pipeline - malformed tag', async () => {
@@ -93,7 +93,7 @@ test('update-pipeline - malformed tag', async () => {
 
   const runResult = UpdatePipelineCommand.run(['--programId', '5', '5', '--tag', 'refs/tags/foo'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:INVALID_TAG_SYNTAX] tag flag should not be specified with "refs/tags/" prefix. Value provided was refs/tags/foo')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:INVALID_TAG_SYNTAX] tag flag should not be specified with "refs/tags/" prefix. Value provided was refs/tags/foo')
 })
 
 test('update-pipeline - correct tag', async () => {

--- a/test/commands/program/delete.test.js
+++ b/test/commands/program/delete.test.js
@@ -23,7 +23,7 @@ test('delete-program - missing arg', async () => {
 
   const runResult = DeleteProgramCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message.indexOf('Missing 1 required arg') === 0)
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
 
 test('delete-program - missing config', async () => {
@@ -31,7 +31,7 @@ test('delete-program - missing config', async () => {
 
   const runResult = DeleteProgramCommand.run(['5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('delete-program - configured', async () => {

--- a/test/commands/program/list-current-executions.test.js
+++ b/test/commands/program/list-current-executions.test.js
@@ -23,7 +23,7 @@ test('list-current-executions - missing arg', async () => {
 
   const runResult = ListCurrentExecutions.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('list-current-executions - missing config', async () => {
@@ -31,7 +31,7 @@ test('list-current-executions - missing config', async () => {
 
   const runResult = ListCurrentExecutions.run(['--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('list-current-executions - success', async () => {

--- a/test/commands/program/list-environments.test.js
+++ b/test/commands/program/list-environments.test.js
@@ -25,7 +25,7 @@ test('list-environments - missing arg', async () => {
 
   const runResult = ListEnvironmentsCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('list-environments - missing config', async () => {
@@ -33,7 +33,7 @@ test('list-environments - missing config', async () => {
 
   const runResult = ListEnvironmentsCommand.run(['--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('list-environments - configured', async () => {

--- a/test/commands/program/list-pipelines.test.js
+++ b/test/commands/program/list-pipelines.test.js
@@ -24,7 +24,7 @@ test('list-pipelines - missing arg', async () => {
 
   const runResult = ListPipelinesCommand.run([])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:MISSING_PROGRAM_ID] Program ID must be specified either as --programId flag or through cloudmanager_programid config value.')
 })
 
 test('list-pipelines - missing config', async () => {
@@ -32,7 +32,7 @@ test('list-pipelines - missing config', async () => {
 
   const runResult = ListPipelinesCommand.run(['--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
 test('list-pipelines - normal', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There's a bunch of usage of `toSatisfy` which isn't really necessary since `toThrow` can be used matching the message either via a string or regex


## Motivation and Context

Simplify test code

## How Has This Been Tested?

Tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
