### PR TITLE
feat(commerce): add get-command fixes #437

### DIFF
--- a/src/commands/cloudmanager/commerce/get-command-execution.js
+++ b/src/commands/cloudmanager/commerce/get-command-execution.js
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const BaseCommand = require('../../../base-command')
+const { initSdk, formatTime, getProgramId } = require('../../../cloudmanager-helpers')
+const { cli } = require('cli-ux')
+const commonFlags = require('../../../common-flags')
+
+class GetCommandExecutionCommand extends BaseCommand {
+  async run () {
+    const { args, flags } = this.parse(GetCommandExecutionCommand)
+
+    const programId = getProgramId(flags)
+
+    const commandRetrievalMessage = `Getting Status for Command ID# ${args.commandExecutionId}`
+    const commandRetrievedMessage = `Status for Command ID# ${args.commandExecutionId}`
+
+    cli.action.start(commandRetrievalMessage)
+
+    const result = await this.getCommand(
+      programId,
+      args.environmentId,
+      args.commandExecutionId,
+    )
+
+    cli.action.start(commandRetrievedMessage)
+    cli.action.stop('\n')
+    const { id, type, command, startedBy, startedAt, completedAt, status } = result
+    cli.table([{ id, type, command, startedBy, startedAt, completedAt, status }], {
+      id: {},
+      type: {},
+      command: {},
+      startedBy: {
+        header: 'Started By',
+      },
+      startedAt: {
+        header: 'Started At',
+        get: formatTime(startedAt),
+      },
+      completedAt: {
+        header: 'Completed At',
+        get: formatTime(completedAt),
+      },
+      status: {},
+    })
+    console.log('\n')
+
+    return result
+  }
+
+  async getCommand (
+    programId,
+    environmentId,
+    commandExecutionId,
+    imsContextName = null,
+  ) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.getCommerceCommandExecution(programId, environmentId, commandExecutionId)
+  }
+}
+
+GetCommandExecutionCommand.description = 'get status of a single commerce cli command'
+
+GetCommandExecutionCommand.flags = {
+  ...commonFlags.global,
+  ...commonFlags.programId,
+}
+
+GetCommandExecutionCommand.args = [
+  { name: 'environmentId', required: true, description: 'the environment id' },
+  { name: 'commandExecutionId', required: true, description: 'the command execution id' },
+]
+
+module.exports = GetCommandExecutionCommand

--- a/test/commands/commerce/get-command-execution.test.js
+++ b/test/commands/commerce/get-command-execution.test.js
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { cli } = require('cli-ux')
+const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
+const GetCommandExecutionCommand = require('../../../src/commands/cloudmanager/commerce/get-command-execution')
+
+beforeEach(() => {
+  resetCurrentOrgId()
+})
+
+test('get-command (commerce) - missing arg', async () => {
+  expect.assertions(4)
+
+  const runResultOne = GetCommandExecutionCommand.run([])
+  await expect(runResultOne instanceof Promise).toBeTruthy()
+  await expect(runResultOne).rejects.toSatisfy(
+    (err) => err.message.indexOf('Missing 2 required args') === 0,
+  )
+  const runResultTwo = GetCommandExecutionCommand.run(['12345'])
+  await expect(runResultTwo instanceof Promise).toBeTruthy()
+  await expect(runResultTwo).rejects.toSatisfy(
+    (err) => err.message.indexOf('Missing 1 required arg') === 0,
+  )
+})
+
+test('get-command (commerce) - missing config', async () => {
+  expect.assertions(2)
+
+  const runResult = GetCommandExecutionCommand.run(['--programId', '5', '10', '20'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+})
+
+test('get-command (commerce)', async () => {
+  setCurrentOrgId('good')
+  mockSdk.getCommerceCommandExecution = jest.fn(() => {
+    return Promise.resolve({
+      id: 100,
+      type: 'bin/magento',
+      command: 'maintenance:status',
+      options: [],
+      startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com',
+      startedAt: '2021-08-17T17:03:18.858+0000',
+      completedAt: '2021-08-17T17:03:43.000+0000',
+      name: 'magento-cli-952',
+      status: 'COMPLETED',
+      environmentId: 177253,
+    })
+  })
+
+  // expect.assertions(9)
+
+  const runResult = GetCommandExecutionCommand.run(['--programId', '5', '10', '100'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await runResult
+  await expect(init.mock.calls.length).toEqual(1)
+  await expect(init).toHaveBeenCalledWith(
+    'good',
+    'test-client-id',
+    'fake-token',
+    'https://cloudmanager.adobe.io',
+  )
+  await expect(mockSdk.getCommerceCommandExecution.mock.calls.length).toEqual(1)
+  await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '100')
+  await expect(cli.action.start.mock.calls[0][0]).toEqual('Getting Status for Command ID# 100')
+  await expect(cli.action.start.mock.calls[1][0]).toEqual('Status for Command ID# 100')
+  await expect(cli.table.mock.calls[0][0]).toEqual([{ command: 'maintenance:status', completedAt: '2021-08-17T17:03:43.000+0000', id: 100, startedAt: '2021-08-17T17:03:18.858+0000', startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com', status: 'COMPLETED', type: 'bin/magento' }])
+  await expect(cli.action.stop).toHaveBeenCalled()
+})
+
+test('get-command (commerce) - api error', async () => {
+  setCurrentOrgId('good')
+  mockSdk.getCommerceCommandExecution = jest.fn(() =>
+    Promise.reject(new Error('Command failed.')),
+  )
+  const runResult = GetCommandExecutionCommand.run(['--programId', '5', '10', '20'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toEqual(new Error('Command failed.'))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This will add a command to allow users to see the status of a single command

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/437

## Motivation and Context

Users that execute a command will need to see the status of the command

## How Has This Been Tested?

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
