### PR TITLE
fix(commerce): fix implementation and test for get-command-execution fixes #441

### DIFF
--- a/src/commands/cloudmanager/commerce/get-command-execution.js
+++ b/src/commands/cloudmanager/commerce/get-command-execution.js
@@ -44,11 +44,11 @@ class GetCommandExecutionCommand extends BaseCommand {
       },
       startedAt: {
         header: 'Started At',
-        get: formatTime(startedAt),
+        get: formatTime('startedAt'),
       },
       completedAt: {
         header: 'Completed At',
-        get: formatTime(completedAt),
+        get: formatTime('completedAt'),
       },
       status: {},
     })

--- a/test/commands/commerce/get-command-execution.test.js
+++ b/test/commands/commerce/get-command-execution.test.js
@@ -19,7 +19,7 @@ beforeEach(() => {
   resetCurrentOrgId()
 })
 
-test('get-command (commerce) - missing arg', async () => {
+test('get-command-execution (commerce) - missing arg', async () => {
   expect.assertions(4)
 
   const runResultOne = GetCommandExecutionCommand.run([])
@@ -34,7 +34,7 @@ test('get-command (commerce) - missing arg', async () => {
   )
 })
 
-test('get-command (commerce) - missing config', async () => {
+test('get-command-execution (commerce) - missing config', async () => {
   expect.assertions(2)
 
   const runResult = GetCommandExecutionCommand.run(['--programId', '5', '10', '20'])
@@ -42,7 +42,7 @@ test('get-command (commerce) - missing config', async () => {
   await expect(runResult).rejects.toSatisfy(err => err.message === '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
-test('get-command (commerce)', async () => {
+test('get-command-execution (commerce)', async () => {
   setCurrentOrgId('good')
   mockSdk.getCommerceCommandExecution = jest.fn(() => {
     return Promise.resolve({
@@ -59,7 +59,7 @@ test('get-command (commerce)', async () => {
     })
   })
 
-  // expect.assertions(9)
+  expect.assertions(9)
 
   const runResult = GetCommandExecutionCommand.run(['--programId', '5', '10', '100'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -79,7 +79,7 @@ test('get-command (commerce)', async () => {
   await expect(cli.action.stop).toHaveBeenCalled()
 })
 
-test('get-command (commerce) - api error', async () => {
+test('get-command-execution (commerce) - api error', async () => {
   setCurrentOrgId('good')
   mockSdk.getCommerceCommandExecution = jest.fn(() =>
     Promise.reject(new Error('Command failed.')),


### PR DESCRIPTION
The table in get-commerce-execution passes the object to the formatTime function in cli.table. These should be strings. Additionally, the test names the command get-command and it should be get-command-execution. Finally, one of the tests had the assertions commented out.

This PR changes the objects to strings in the formatTime function. It renames the test to match the command. It also removes the commented out assertion in the test.

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/441

## Motivation and Context

It fixes a few bugs in the implementation of get-commerce-execution

## How Has This Been Tested?

unit tests


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
