### PR TITLE
feat(commerce): list command executions fixes #440

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-cloudmanager/issues",
   "dependencies": {
-    "@adobe/aio-lib-cloudmanager": "^1.4.0",
+    "@adobe/aio-lib-cloudmanager": "^1.5.0",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-errors": "^3.0.1",
     "@adobe/aio-lib-core-logging": "^1.2.0",

--- a/src/commands/cloudmanager/commerce/list-command-executions.js
+++ b/src/commands/cloudmanager/commerce/list-command-executions.js
@@ -1,0 +1,134 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const BaseCommand = require('../../../base-command')
+const {
+  initSdk,
+  formatTime,
+  getProgramId,
+} = require('../../../cloudmanager-helpers')
+const { cli } = require('cli-ux')
+const { flags } = require('@oclif/command')
+const commonFlags = require('../../../common-flags')
+
+class ListCommandExecutionsCommand extends BaseCommand {
+  async run () {
+    const { args, flags } = this.parse(ListCommandExecutionsCommand)
+
+    const programId = getProgramId(flags)
+
+    const commandsRetrievalMessage = 'Getting Commerce Command Executions'
+    const commandsRetrievedMessage = 'Retrieved Commerce Command Executions'
+
+    cli.action.start(commandsRetrievalMessage)
+
+    const result = await this.getCommands(
+      programId,
+      args.environmentId,
+      flags.type,
+      flags.status,
+      flags.command,
+    )
+
+    cli.action.start(commandsRetrievedMessage)
+    cli.action.stop('\n')
+
+    cli.table(result, {
+      id: {},
+      type: {},
+      command: {},
+      startedBy: {
+        header: 'Started By',
+      },
+      startedAt: {
+        header: 'Started At',
+        get: formatTime('startedAt'),
+      },
+      completedAt: {
+        header: 'Completed At',
+        get: formatTime('completedAt'),
+      },
+      status: {},
+    })
+    console.log('\n')
+
+    return result
+  }
+
+  async getCommands (
+    programId,
+    environmentId,
+    type,
+    status,
+    command,
+    imsContextName = null,
+  ) {
+    const sdk = await initSdk(imsContextName)
+    return sdk.getCommerceCommandExecutions(
+      programId,
+      environmentId,
+      type,
+      status,
+      command,
+    )
+  }
+}
+
+ListCommandExecutionsCommand.description =
+  'get status of a single commerce cli command'
+
+ListCommandExecutionsCommand.flags = {
+  ...commonFlags.global,
+  ...commonFlags.programId,
+  type: flags.string({
+    char: 't',
+    required: false,
+    description: 'filter by type of command',
+    options: ['bin/magento'],
+  }),
+  status: flags.string({
+    char: 's',
+    required: false,
+    description: 'filter by status of command',
+    options: [
+      'PENDING',
+      'RUNNING',
+      'CANCELLED',
+      'COMPLETED',
+      'FAILED',
+      'CANCELLING',
+      'CANCEL_FAILED',
+      'UNKNOWN',
+    ],
+  }),
+  command: flags.string({
+    char: 'c',
+    required: false,
+    description: 'filter by command',
+    options: [
+      'maintenance:status',
+      'maintenance:enable',
+      'maintenance:disable',
+      'indexer:reindex',
+      'cache:clean',
+      'cache:flush',
+      'app:config:dump',
+      'app:config:import',
+    ],
+  }),
+}
+
+ListCommandExecutionsCommand.args = [
+  { name: 'environmentId', required: true, description: 'the environment id' },
+]
+
+module.exports = ListCommandExecutionsCommand

--- a/test/commands/commerce/list-command-executions.test.js
+++ b/test/commands/commerce/list-command-executions.test.js
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { cli } = require('cli-ux')
+const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
+const ListCommandExecutionsCommand = require('../../../src/commands/cloudmanager/commerce/list-command-executions')
+
+beforeEach(() => {
+  resetCurrentOrgId()
+})
+
+test('list-command-executions (commerce) - missing arg', async () => {
+  expect.assertions(2)
+
+  const runResult = ListCommandExecutionsCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toSatisfy(
+    (err) => err.message.indexOf('Missing 1 required arg') === 0,
+  )
+})
+
+test('list-command-executions (commerce) - missing config', async () => {
+  expect.assertions(2)
+
+  const runResult = ListCommandExecutionsCommand.run([
+    '--programId',
+    '5',
+    '10',
+  ])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toSatisfy(
+    (err) =>
+      err.message ===
+      '[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.',
+  )
+})
+
+test('list-command-executions (commerce)', async () => {
+  setCurrentOrgId('good')
+  const result = [
+    {
+      id: 100,
+      type: 'bin/magento',
+      command: 'maintenance:status',
+      options: [],
+      startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com',
+      startedAt: '2021-08-17T17:03:18.858+0000',
+      completedAt: '2021-08-17T17:03:43.000+0000',
+      name: 'magento-cli-952',
+      status: 'COMPLETED',
+      environmentId: 177253,
+    },
+    {
+      id: 101,
+      type: 'bin/magento',
+      command: 'cache:clean',
+      options: [],
+      startedBy: 'E64A64C360706AD20A494012@techacct.adobe.com',
+      startedAt: '2021-08-17T17:03:18.858+0000',
+      completedAt: '2021-08-17T17:03:43.000+0000',
+      name: 'magento-cli-952',
+      status: 'COMPLETED',
+      environmentId: 177253,
+    },
+  ]
+  mockSdk.getCommerceCommandExecutions = jest.fn(() => {
+    return Promise.resolve(result)
+  })
+
+  // expect.assertions(9)
+
+  const runResult = ListCommandExecutionsCommand.run([
+    '--programId',
+    '5',
+    '10',
+  ])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await runResult
+  await expect(init.mock.calls.length).toEqual(1)
+  await expect(init).toHaveBeenCalledWith(
+    'good',
+    'test-client-id',
+    'fake-token',
+    'https://cloudmanager.adobe.io',
+  )
+  await expect(mockSdk.getCommerceCommandExecutions.mock.calls.length).toEqual(
+    1,
+  )
+  await expect(mockSdk.getCommerceCommandExecutions).toHaveBeenCalledWith(
+    '5',
+    '10',
+    undefined,
+    undefined,
+    undefined,
+  )
+  await expect(cli.action.start.mock.calls[0][0]).toEqual(
+    'Getting Commerce Command Executions',
+  )
+  await expect(cli.action.start.mock.calls[1][0]).toEqual(
+    'Retrieved Commerce Command Executions',
+  )
+  await expect(cli.table.mock.calls[0][0]).toEqual(result)
+  await expect(cli.action.stop).toHaveBeenCalled()
+})
+
+test('list-command-executions (commerce) - api error', async () => {
+  setCurrentOrgId('good')
+  mockSdk.getCommerceCommandExecutions = jest.fn(() =>
+    Promise.reject(new Error('Command failed.')),
+  )
+  const runResult = ListCommandExecutionsCommand.run([
+    '--programId',
+    '5',
+    '10',
+  ])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toEqual(new Error('Command failed.'))
+})


### PR DESCRIPTION
This PR will add a command to list all executions for a given program and environment.

## Description

In addition to list commands for a given program and environment the command allows the user to use optional flags to filter by type, status and command.

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/440

## Motivation and Context

This solves the need for a command to list the status and details for all commerce cli command executions

## How Has This Been Tested?

Unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
