### PR TITLE
fix(hook): default environment id does not work when the command has …

### DIFF
--- a/src/hooks/prerun/environment-id-from-config.js
+++ b/src/hooks/prerun/environment-id-from-config.js
@@ -32,7 +32,7 @@ module.exports = function (hookOptions) {
         try {
           return originalParse.call(this, options)
         } catch (e) {
-          if (e instanceof RequiredArgsError && e.args && e.args.length === 1 && e.args[0].name === 'environmentId') {
+          if (e instanceof RequiredArgsError && e.args && e.args.length === 1) {
             return originalParse.call(this, options, [environmentId, ...hookOptions.argv])
           } else {
             throw e

--- a/test/hooks/prerun/environment-id-from-config.test.js
+++ b/test/hooks/prerun/environment-id-from-config.test.js
@@ -39,7 +39,18 @@ test('hook -- environmentId args and no config', async () => {
     Command: FixtureWithEnvironmentIdArg,
     argv: [],
   })
-  new FixtureWithNoArgs().parse(FixtureWithEnvironmentIdArg, [])
+  new FixtureWithEnvironmentIdArg().parse(FixtureWithEnvironmentIdArg, [])
+  expect(parse.mock.calls.length).toEqual(1)
+})
+
+test('hook -- two args and no config', async () => {
+  expect.assertions(1)
+
+  await hook({
+    Command: FixtureWithEnvironmentIdArgAndAnotherArg,
+    argv: [],
+  })
+  new FixtureWithEnvironmentIdArgAndAnotherArg().parse(FixtureWithEnvironmentIdArgAndAnotherArg, [])
   expect(parse.mock.calls.length).toEqual(1)
 })
 
@@ -61,6 +72,26 @@ test('hook -- environmentId args with config', async () => {
   new FixtureWithEnvironmentIdArg().parse(FixtureWithEnvironmentIdArg, [])
   expect(parse.mock.calls.length).toEqual(2)
   expect(parse.mock.calls[1][1]).toEqual(['4321'])
+})
+
+test('hook -- two args with config', async () => {
+  setStore({
+    cloudmanager_environmentid: '4321',
+  })
+
+  parse = jest.fn().mockImplementationOnce(() => {
+    throw new RequiredArgsError({ args: [{ name: 'environmentId' }] })
+  }).mockImplementationOnce(() => true)
+
+  expect.assertions(2)
+
+  await hook({
+    Command: FixtureWithEnvironmentIdArgAndAnotherArg,
+    argv: ['abcd'],
+  })
+  new FixtureWithEnvironmentIdArgAndAnotherArg().parse(FixtureWithEnvironmentIdArgAndAnotherArg, [])
+  expect(parse.mock.calls.length).toEqual(2)
+  expect(parse.mock.calls[1][1]).toEqual(['4321', 'abcd'])
 })
 
 test('hook -- multiple missing args with config', async () => {
@@ -138,6 +169,18 @@ FixtureWithEnvironmentIdArg.args = [
   { name: 'environmentId' },
 ]
 FixtureWithEnvironmentIdArg.plugin = thisPlugin
+
+class FixtureWithEnvironmentIdArgAndAnotherArg {
+  parse (options, argv) {
+    parse(options, argv)
+  }
+}
+
+FixtureWithEnvironmentIdArgAndAnotherArg.args = [
+  { name: 'environmentId' },
+  { name: 'somethingElse' },
+]
+FixtureWithEnvironmentIdArgAndAnotherArg.plugin = thisPlugin
 
 class FixtureWithEnvironmentIdArgFromOtherPlugin {
   parse (options, argv) {


### PR DESCRIPTION
…multiple args. fixes #443

<!--- Provide a general summary of your changes in the Title above -->

## Description

The default environment id hook was only operational for commands with environmentId was the *only* argument. That wasn't intended.

## Related Issue

#443 

## Motivation and Context

Bug

## How Has This Been Tested?

Unit test improved
Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
