### PR TITLE
fix(environmentId): make environmentId a common arg fixes #457

### DIFF
--- a/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
 const { getProgramId } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
+const commonArgs = require('../../../../../common-args')
 
 class IndexerReindexCommand extends BaseCommerceCliCommand {
   async run () {
@@ -39,7 +40,7 @@ IndexerReindexCommand.flags = {
 }
 
 IndexerReindexCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 IndexerReindexCommand.aliases = [

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
 const { getProgramId } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
+const commonArgs = require('../../../../../common-args')
 
 class MaintenanceStatusCommand extends BaseCommerceCliCommand {
   async run () {
@@ -39,7 +40,7 @@ MaintenanceStatusCommand.flags = {
 }
 
 MaintenanceStatusCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 MaintenanceStatusCommand.aliases = [

--- a/src/commands/cloudmanager/commerce/get-command-execution.js
+++ b/src/commands/cloudmanager/commerce/get-command-execution.js
@@ -14,6 +14,7 @@ const BaseCommand = require('../../../base-command')
 const { initSdk, formatTime, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 
 class GetCommandExecutionCommand extends BaseCommand {
   async run () {
@@ -76,7 +77,7 @@ GetCommandExecutionCommand.flags = {
 }
 
 GetCommandExecutionCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
   { name: 'commandExecutionId', required: true, description: 'the command execution id' },
 ]
 

--- a/src/commands/cloudmanager/commerce/list-command-executions.js
+++ b/src/commands/cloudmanager/commerce/list-command-executions.js
@@ -19,6 +19,7 @@ const {
 const { cli } = require('cli-ux')
 const { flags } = require('@oclif/command')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 
 class ListCommandExecutionsCommand extends BaseCommand {
   async run () {
@@ -128,7 +129,7 @@ ListCommandExecutionsCommand.flags = {
 }
 
 ListCommandExecutionsCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 module.exports = ListCommandExecutionsCommand

--- a/src/commands/cloudmanager/environment/bind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/bind-ip-allowlist.js
@@ -36,7 +36,7 @@ class BindIPAllowlist extends BaseCommand {
 BindIPAllowlist.description = 'Bind an IP Allowlist to an environment'
 
 BindIPAllowlist.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
   commonArgs.service,
 ]

--- a/src/commands/cloudmanager/environment/delete.js
+++ b/src/commands/cloudmanager/environment/delete.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 const BaseCommand = require('../../../base-command')
 
 class DeleteEnvironmentCommand extends BaseCommand {
@@ -46,7 +47,7 @@ DeleteEnvironmentCommand.flags = {
 }
 
 DeleteEnvironmentCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 DeleteEnvironmentCommand.aliases = [

--- a/src/commands/cloudmanager/environment/download-logs.js
+++ b/src/commands/cloudmanager/environment/download-logs.js
@@ -15,6 +15,7 @@ const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloud
 const { cli } = require('cli-ux')
 const path = require('path')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 const BaseCommand = require('../../../base-command')
 
 class DownloadLogs extends BaseCommand {
@@ -57,7 +58,7 @@ class DownloadLogs extends BaseCommand {
 DownloadLogs.description = 'downloads log files for the specified environment, service and log name for one or more days'
 
 DownloadLogs.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
   { name: 'service', required: true, description: 'the service' },
   { name: 'name', required: true, description: 'the log name' },
   { name: 'days', required: false, description: 'the number of days', default: '1' },

--- a/src/commands/cloudmanager/environment/list-available-log-options.js
+++ b/src/commands/cloudmanager/environment/list-available-log-options.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const { initSdk, getProgramId, sanitizeEnvironmentId, getOutputFormat } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 const BaseCommand = require('../../../base-command')
 
 class ListAvailableLogOptionsCommand extends BaseCommand {
@@ -53,7 +54,7 @@ class ListAvailableLogOptionsCommand extends BaseCommand {
 ListAvailableLogOptionsCommand.description = 'lists available log options for an environment in a Cloud Manager program'
 
 ListAvailableLogOptionsCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 ListAvailableLogOptionsCommand.flags = {

--- a/src/commands/cloudmanager/environment/list-ip-allowlist-bindings.js
+++ b/src/commands/cloudmanager/environment/list-ip-allowlist-bindings.js
@@ -14,6 +14,7 @@ const { getProgramId, getOutputFormat, columnWithArray } = require('../../../clo
 const { cli } = require('cli-ux')
 const _ = require('lodash')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 const ListIpAllowlists = require('../program/list-ip-allowlists')
 const BaseCommand = require('../../../base-command')
 
@@ -55,7 +56,7 @@ class ListIPAllowlistBindings extends BaseCommand {
 ListIPAllowlistBindings.description = 'lists IP Allowlists bound to an environment'
 
 ListIPAllowlistBindings.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 ListIPAllowlistBindings.flags = {

--- a/src/commands/cloudmanager/environment/list-variables.js
+++ b/src/commands/cloudmanager/environment/list-variables.js
@@ -14,6 +14,7 @@ const BaseEnvironmentVariablesCommand = require('../../../base-environment-varia
 const BaseVariablesCommand = require('../../../base-variables-command')
 const { getProgramId } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 
 class ListEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
   async run () {
@@ -32,7 +33,7 @@ class ListEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
 ListEnvironmentVariablesCommand.description = 'lists variables set on an environment'
 
 ListEnvironmentVariablesCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 ListEnvironmentVariablesCommand.flags = {

--- a/src/commands/cloudmanager/environment/open-developer-console.js
+++ b/src/commands/cloudmanager/environment/open-developer-console.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 const BaseCommand = require('../../../base-command')
 
 class OpenDeveloperConsoleCommand extends BaseCommand {
@@ -39,7 +40,7 @@ class OpenDeveloperConsoleCommand extends BaseCommand {
 OpenDeveloperConsoleCommand.description = 'opens the Developer Console, if available, in a browser'
 
 OpenDeveloperConsoleCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 OpenDeveloperConsoleCommand.flags = {

--- a/src/commands/cloudmanager/environment/set-variables.js
+++ b/src/commands/cloudmanager/environment/set-variables.js
@@ -17,6 +17,7 @@ const { flags } = require('@oclif/command')
 const Config = require('@adobe/aio-lib-core-config')
 const _ = require('lodash')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 const { services } = require('../../../constants')
 const { codes: validationCodes } = require('../../../ValidationErrors')
 
@@ -70,7 +71,7 @@ class SetEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
 SetEnvironmentVariablesCommand.description = 'sets variables set on an environment. These are runtime variables available to components running inside the runtime environment. Use set-pipeline-variables to set build-time variables on a pipeline.'
 
 SetEnvironmentVariablesCommand.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
 ]
 
 SetEnvironmentVariablesCommand.flags = {

--- a/src/commands/cloudmanager/environment/tail-log.js
+++ b/src/commands/cloudmanager/environment/tail-log.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const BaseCommand = require('../../../base-command')
 const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
+const commonArgs = require('../../../common-args')
 
 class TailLog extends BaseCommand {
   async run () {
@@ -38,7 +39,7 @@ class TailLog extends BaseCommand {
 TailLog.description = 'outputs a stream of log data for the specified environment, service and log name'
 
 TailLog.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
   { name: 'service', required: true, description: 'the service' },
   { name: 'name', required: true, description: 'the log name' },
 ]

--- a/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
@@ -38,7 +38,7 @@ UnbindIPAllowlist.description = 'Bind an IP Allowlist to an environment'
 UnbindIPAllowlist.strict = false
 
 UnbindIPAllowlist.args = [
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
   commonArgs.service,
 ]

--- a/src/commands/cloudmanager/ip-allowlist/bind.js
+++ b/src/commands/cloudmanager/ip-allowlist/bind.js
@@ -43,7 +43,7 @@ BindIPAllowlist.strict = false
 
 BindIPAllowlist.args = [
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
   commonArgs.service,
 ]
 

--- a/src/commands/cloudmanager/ip-allowlist/unbind.js
+++ b/src/commands/cloudmanager/ip-allowlist/unbind.js
@@ -43,7 +43,7 @@ UnbindIPAllowlist.strict = false
 
 UnbindIPAllowlist.args = [
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
-  { name: 'environmentId', required: true, description: 'the environment id' },
+  commonArgs.environmentId,
   commonArgs.service,
 ]
 

--- a/src/common-args.js
+++ b/src/common-args.js
@@ -14,4 +14,5 @@ const { services } = require('./constants')
 
 module.exports = {
   service: { name: 'service', required: true, options: services, description: 'the service name' },
+  environmentId: { name: 'environmentId', required: true, description: 'the environment id' },
 }


### PR DESCRIPTION
This pr will update all instances of environmentId declared as a one-off argument in commands

<!--- Describe your changes in detail -->

All of the instances of environmentId that were declared in the args object of commands are replaced by an imported environmentId arg that is located in the central commonArgs file.

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/457

## Motivation and Context

The above issue

## How Has This Been Tested?

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
