### PR TITLE
feat(commerce): add maintenance:disable fixes #466

### DIFF
--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/disable.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/disable.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
+const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const commonFlags = require('../../../../../common-flags')
+const commonArgs = require('../../../../../common-args')
+
+class MaintenanceDisableCommand extends BaseCommerceCliCommand {
+  async run () {
+    const { args, flags } = this.parse(MaintenanceDisableCommand)
+
+    const programId = getProgramId(flags)
+
+    const result = await this.runSync(programId, args.environmentId,
+      {
+        type: 'bin/magento',
+        command: 'maintenance:disable',
+      },
+      1000, 'maintenance:disable')
+
+    return result
+  }
+}
+
+MaintenanceDisableCommand.description = 'commerce maintenance disable'
+
+MaintenanceDisableCommand.flags = {
+  ...commonFlags.global,
+  ...commonFlags.programId,
+}
+
+MaintenanceDisableCommand.args = [
+  commonArgs.environmentId,
+]
+
+MaintenanceDisableCommand.aliases = [
+  'cloudmanager:commerce:maintenance-disable',
+]
+
+module.exports = MaintenanceDisableCommand

--- a/test/commands/commerce/bin-magento/maintenance/disable.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/disable.test.js
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { cli } = require('cli-ux')
+const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
+const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
+const MaintenanceDisableCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/disable')
+
+beforeEach(() => {
+  resetCurrentOrgId()
+})
+
+test('maintenance:disable - missing arg', async () => {
+  expect.assertions(2)
+
+  const runResult = MaintenanceDisableCommand.run([])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
+})
+
+test('maintenance:disable - missing config', async () => {
+  expect.assertions(2)
+
+  const runResult = MaintenanceDisableCommand.run(['--programId', '5', '10'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
+})
+
+test('maintenance:disable', async () => {
+  let counter = 0
+  setCurrentOrgId('good')
+  mockSdk.postCommerceCommandExecution = jest.fn(() =>
+    Promise.resolve({
+      id: '5000',
+    }),
+  )
+  mockSdk.getCommerceCommandExecution = jest.fn(() => {
+    counter++
+    if (counter === 1) {
+      return Promise.resolve({
+        status: 'PENDING',
+        message: 'running maintenance disable',
+      })
+    } else if (counter < 3) {
+      return Promise.resolve({
+        status: 'RUNNING',
+        message: 'running maintenance disable',
+      })
+    }
+    return Promise.resolve({
+      status: 'COMPLETE',
+      message: 'maintenance disabled',
+    })
+  })
+
+  expect.assertions(11)
+
+  const runResult = MaintenanceDisableCommand.run(['--programId', '5', '10'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await runResult
+  await expect(init.mock.calls.length).toEqual(1)
+  await expect(init).toHaveBeenCalledWith(
+    'good',
+    'test-client-id',
+    'fake-token',
+    'https://cloudmanager.adobe.io',
+  )
+  await expect(mockSdk.postCommerceCommandExecution.mock.calls.length).toEqual(1)
+  await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
+    type: 'bin/magento',
+    command: 'maintenance:disable',
+  })
+  await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
+  await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
+  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting maintenance:disable')
+  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting maintenance:disable')
+  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running maintenance:disable')
+  await expect(cli.action.stop.mock.calls[0][0]).toEqual('maintenance disabled')
+})
+
+test('maintenance:disable - api error', async () => {
+  setCurrentOrgId('good')
+  mockSdk.postCommerceCommandExecution = jest.fn(() =>
+    Promise.reject(new Error('Command failed.')),
+  )
+  mockSdk.getCommerceCommandExecution = jest.fn()
+  const runResult = MaintenanceDisableCommand.run(['--programId', '5', '10'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).rejects.toEqual(new Error('Command failed.'))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR will add a maintenance:disable command execution for Commerce programs.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/466

## How Has This Been Tested?

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
