### PR TITLE
feat: add permissions virtual flag. fixes #175

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,18 @@
         "rules" : {
           "aio-cli-plugin-cloudmanager-error-usage": "off"
         }
+      },
+      {
+        "files" : ["src/commands/**/*.js"],
+        "rules" : {
+          "aio-cli-plugin-cloudmanager-command-permissions": "error"
+        }
+      },
+      {
+        "files" : ["src/commands/cloudmanager/commerce/**/*.js"],
+        "rules" : {
+          "aio-cli-plugin-cloudmanager-command-permissions": "off"
+        }
       }
     ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ junit.xml
 .vscode/
 /package-lock.json
 .aio
+permissions.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,13 @@ In order to ensure proper error handling, individual commands should generally *
 
 Hooks should work in a similar fashion -- see the prerun `check-ims-context-config` hook as a point of reference.
 
+## Custom Command Class Properties
+
+In addition to the standard [oclif command properties](https://oclif.io/docs/commands), commands in this plugin may define these extra properties:
+
+* `skipOrgIdCheck` -- This should be set to `true` if the command does *not* require an IMS Organization ID to be configured in the current IMS context. This is primarily used when using browser-based authentication as service account authentication will always have an organization ID.
+* `permissionInfo` -- This is used to output information to the CLI user about the permissions required to execute a particular command. This must be an object. Currently a single key is supported `operation` which must correspond to one of the operations defined in https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json. If a command doesn't require specific permissions (e.g. is a read-only operation), this should be set to an empty object.
+
 ## Commits and Releasing
 
 Commits (generally via merged pull requests) to the `main` branch of this repository will automatically generate [semantically versioned releases](https://github.com/semantic-release). To accomplish this, commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax, specifically:

--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,16 @@ ALIASES
 _See code: [src/commands/cloudmanager/program/list-pipelines.js](https://github.com/adobe/aio-cli-plugin-cloudmanager/blob/2.13.0/src/commands/cloudmanager/program/list-pipelines.js)_
 <!-- commandsstop -->
 
+# Permissions
+
+Information about Cloud Manager API permissions can be found on https://www.adobe.io/experience-cloud/cloud-manager/guides/getting-started/permissions/. To see the
+permissions required for a specific command, you can also run any command with the flag `--permissions`, e.g.
+
+```
+$ aio cloudmanager:current-execution:advance --permissions
+To execute cloudmanager:current-execution:advance, one of the following product profiles is required: Business Owner, Deployment Manager, Program Manager
+```
+
 # Variables From Standard Input
 
 The `environment:set-variables` and `pipeline:set-variables` commands allow for variables to be passed both as flags to the command and as a JSON array provided as standard input or as a file. The objects in this array are expected to have a `name`, `value`, and `type` keys following the same syntax as the Cloud Manager API. Deleting a variable can be done by passing an empty `value`. For example, given a file named `variables.json` that contains this:

--- a/eslint_rules/aio-cli-plugin-cloudmanager-command-permissions.js
+++ b/eslint_rules/aio-cli-plugin-cloudmanager-command-permissions.js
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const availableOperations = require('../permissions.json').map(perm => perm.operation)
+
+module.exports = {
+  create: function (context) {
+    return {
+      Program: (node) => {
+        const classDeclarations = node.body.filter(bodyNode => bodyNode.type === 'ClassDeclaration')
+        if (classDeclarations.length === 0) {
+          context.report({
+            node: node,
+            message: "Command file didn't contain command",
+          })
+        }
+        classDeclarations.forEach(classDeclaration => {
+          const className = classDeclaration.id.name
+          const propertiesAssignedToClass = node.body.map(bodyNode => {
+            if (bodyNode.type === 'ExpressionStatement' && bodyNode.expression.type === 'AssignmentExpression' &&
+              bodyNode.expression.left.type === 'MemberExpression' && bodyNode.expression.left.object && bodyNode.expression.left.object.name === className &&
+              bodyNode.expression.left.property) {
+              return {
+                name: bodyNode.expression.left.property.name,
+                node: bodyNode.expression.right,
+              }
+            }
+            return {}
+          }).filter(property => property.name)
+
+          // if skipOrgIdCheck is defined, we don't need permissions
+          if (!propertiesAssignedToClass.find(prop => prop.name === 'skipOrgIdCheck')) {
+            const permissionInfo = propertiesAssignedToClass.find(prop => prop.name === 'permissionInfo')
+            if (!permissionInfo) {
+              context.report({
+                node: classDeclaration,
+                message: 'Class {{ className }} does not define permissionInfo.',
+                data: {
+                  className,
+                },
+              })
+            } else if (permissionInfo.node.type !== 'ObjectExpression') {
+              context.report({
+                node: permissionInfo.node,
+                message: 'Class {{ className }} has permissionInfo but it is not an object.',
+                data: {
+                  className,
+                },
+              })
+            } else {
+              const operation = permissionInfo.node.properties.find(prop => prop.key.name === 'operation')
+              if (operation && operation.value) {
+                if (operation.value.type !== 'Literal') {
+                  context.report({
+                    node: permissionInfo.node,
+                    message: 'Class {{ className }} has permissionInfo with operation {{ operation }} but it is not a literal.',
+                    data: {
+                      className,
+                      operation,
+                    },
+                  })
+                } else if (!availableOperations.includes(operation.value.value)) {
+                  context.report({
+                    node: permissionInfo.node,
+                    message: 'Class {{ className }} has permissionInfo with operation {{ operation }} but that operation is not defined.',
+                    data: {
+                      className,
+                      operation: operation.value.value,
+                    },
+                  })
+                }
+              }
+            }
+          }
+        })
+      },
+    }
+  },
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "halfred": "^2.0.0",
     "inquirer": "^8.1.0",
     "lodash": "^4.17.15",
-    "moment": "^2.29.0"
+    "moment": "^2.29.0",
+    "node-fetch": "^2.6.2"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "1.3.0",
@@ -40,10 +41,12 @@
     "eslint-plugin-promise": "5.1.0",
     "eslint-plugin-standard": "4.1.0",
     "execa": "5.1.1",
+    "fetch-mock": "9.11.0",
     "husky": "5.2.0",
     "jest": "27.2.0",
     "jest-extended": "0.11.5",
     "jest-junit": "12.2.0",
+    "node-wget": "0.4.3",
     "pinst": "2.1.6",
     "semantic-release": "17.4.7",
     "stdout-stderr": "0.1.13",
@@ -74,7 +77,10 @@
     "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>",
     "hooks": {
       "prerun": "./src/hooks/prerun/prerun-all.js",
-      "init": "./src/hooks/init/migrate-jwt-context-hook.js"
+      "init": [
+        "./src/hooks/init/migrate-jwt-context-hook.js",
+        "./src/hooks/init/load-permission-info.js"
+      ]
     },
     "topics": {
       "cloudmanager": {
@@ -125,7 +131,8 @@
   },
   "scripts": {
     "posttest": "npm run lint",
-    "lint": "eslint src test e2e --rulesdir eslint_rules",
+    "lint:download-permissions": "wget https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json",
+    "lint": "npm run lint:download-permissions && eslint src test e2e --rulesdir eslint_rules",
     "lint-fix": "eslint src test e2e --fix --rulesdir eslint_rules",
     "test": "npm run unit-tests",
     "unit-tests": "jest --ci",

--- a/src/cloudmanager-hook-helpers.js
+++ b/src/cloudmanager-hook-helpers.js
@@ -11,9 +11,18 @@ governing permissions and limitations under the License.
 */
 
 function isThisPlugin (hookOptions) {
-  return hookOptions.Command.plugin.name === '@adobe/aio-cli-plugin-cloudmanager'
+  if (hookOptions && hookOptions.Command) {
+    return hookOptions.Command.plugin.name === '@adobe/aio-cli-plugin-cloudmanager'
+  } else if (hookOptions && hookOptions.id) {
+    return hookOptions.id.startsWith('cloudmanager:')
+  }
+}
+
+function isPermissionsRequest (hookOptions) {
+  return hookOptions.argv && hookOptions.argv.length === 1 && hookOptions.argv[0] === '--permissions'
 }
 
 module.exports = {
   isThisPlugin,
+  isPermissionsRequest,
 }

--- a/src/commands/cloudmanager/current-execution/advance.js
+++ b/src/commands/cloudmanager/current-execution/advance.js
@@ -51,4 +51,8 @@ AdvanceCurrentExecutionCommand.aliases = [
   'cloudmanager:advance-current-execution',
 ]
 
+AdvanceCurrentExecutionCommand.permissionInfo = {
+  operation: 'advancePipelineExecution',
+}
+
 module.exports = AdvanceCurrentExecutionCommand

--- a/src/commands/cloudmanager/current-execution/cancel.js
+++ b/src/commands/cloudmanager/current-execution/cancel.js
@@ -51,4 +51,8 @@ CancelCurrentExecutionCommand.aliases = [
   'cloudmanager:cancel-current-execution',
 ]
 
+CancelCurrentExecutionCommand.permissionInfo = {
+  operation: 'cancelPipelineExecutionStep',
+}
+
 module.exports = CancelCurrentExecutionCommand

--- a/src/commands/cloudmanager/current-execution/get.js
+++ b/src/commands/cloudmanager/current-execution/get.js
@@ -49,4 +49,6 @@ GetCurrentExecutionCommand.aliases = [
   'cloudmanager:get-current-execution',
 ]
 
+GetCurrentExecutionCommand.permissionInfo = {}
+
 module.exports = GetCurrentExecutionCommand

--- a/src/commands/cloudmanager/environment/bind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/bind-ip-allowlist.js
@@ -46,4 +46,8 @@ BindIPAllowlist.flags = {
   ...commonFlags.programId,
 }
 
+BindIPAllowlist.permissionInfo = {
+  operation: 'createIPAllowlistBinding',
+}
+
 module.exports = BindIPAllowlist

--- a/src/commands/cloudmanager/environment/delete.js
+++ b/src/commands/cloudmanager/environment/delete.js
@@ -54,4 +54,8 @@ DeleteEnvironmentCommand.aliases = [
   'cloudmanager:delete-environment',
 ]
 
+DeleteEnvironmentCommand.permissionInfo = {
+  operation: 'deleteEnvironment',
+}
+
 module.exports = DeleteEnvironmentCommand

--- a/src/commands/cloudmanager/environment/download-logs.js
+++ b/src/commands/cloudmanager/environment/download-logs.js
@@ -74,4 +74,6 @@ DownloadLogs.aliases = [
   'cloudmanager:download-logs',
 ]
 
+DownloadLogs.permissionInfo = {}
+
 module.exports = DownloadLogs

--- a/src/commands/cloudmanager/environment/list-available-log-options.js
+++ b/src/commands/cloudmanager/environment/list-available-log-options.js
@@ -67,4 +67,6 @@ ListAvailableLogOptionsCommand.aliases = [
   'cloudmanager:list-available-log-options',
 ]
 
+ListAvailableLogOptionsCommand.permissionInfo = {}
+
 module.exports = ListAvailableLogOptionsCommand

--- a/src/commands/cloudmanager/environment/list-ip-allowlist-bindings.js
+++ b/src/commands/cloudmanager/environment/list-ip-allowlist-bindings.js
@@ -69,4 +69,6 @@ ListIPAllowlistBindings.aliases = [
   'cloudmanager:environment:list-bound-ip-allowlists',
 ]
 
+ListIPAllowlistBindings.permissionInfo = {}
+
 module.exports = ListIPAllowlistBindings

--- a/src/commands/cloudmanager/environment/list-variables.js
+++ b/src/commands/cloudmanager/environment/list-variables.js
@@ -46,4 +46,6 @@ ListEnvironmentVariablesCommand.aliases = [
   'cloudmanager:list-environment-variables',
 ]
 
+ListEnvironmentVariablesCommand.permissionInfo = {}
+
 module.exports = ListEnvironmentVariablesCommand

--- a/src/commands/cloudmanager/environment/open-developer-console.js
+++ b/src/commands/cloudmanager/environment/open-developer-console.js
@@ -52,4 +52,6 @@ OpenDeveloperConsoleCommand.aliases = [
   'cloudmanager:open-developer-console',
 ]
 
+OpenDeveloperConsoleCommand.permissionInfo = {}
+
 module.exports = OpenDeveloperConsoleCommand

--- a/src/commands/cloudmanager/environment/set-variables.js
+++ b/src/commands/cloudmanager/environment/set-variables.js
@@ -96,4 +96,8 @@ SetEnvironmentVariablesCommand.aliases = [
   'cloudmanager:set-environment-variables',
 ]
 
+SetEnvironmentVariablesCommand.permissionInfo = {
+  operation: 'patchEnvironmentVariables',
+}
+
 module.exports = SetEnvironmentVariablesCommand

--- a/src/commands/cloudmanager/environment/tail-log.js
+++ b/src/commands/cloudmanager/environment/tail-log.js
@@ -51,4 +51,6 @@ TailLog.flags = {
 
 TailLog.aliases = ['cloudmanager:tail-logs', 'cloudmanager:tail-log']
 
+TailLog.permissionInfo = {}
+
 module.exports = TailLog

--- a/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
@@ -48,4 +48,8 @@ UnbindIPAllowlist.flags = {
   ...commonFlags.programId,
 }
 
+UnbindIPAllowlist.permissionInfo = {
+  operation: 'deleteIPAllowlistBinding',
+}
+
 module.exports = UnbindIPAllowlist

--- a/src/commands/cloudmanager/execution/get-quality-gate-results.js
+++ b/src/commands/cloudmanager/execution/get-quality-gate-results.js
@@ -108,4 +108,6 @@ GetQualityGateResults.aliases = [
   'cloudmanager:get-quality-gate-results',
 ]
 
+GetQualityGateResults.permissionInfo = {}
+
 module.exports = GetQualityGateResults

--- a/src/commands/cloudmanager/execution/get-step-details.js
+++ b/src/commands/cloudmanager/execution/get-step-details.js
@@ -90,4 +90,6 @@ GetExecutionStepDetails.aliases = [
   'cloudmanager:get-execution-step-details',
 ]
 
+GetExecutionStepDetails.permissionInfo = {}
+
 module.exports = GetExecutionStepDetails

--- a/src/commands/cloudmanager/execution/get-step-log.js
+++ b/src/commands/cloudmanager/execution/get-step-log.js
@@ -75,4 +75,6 @@ GetExecutionStepLogs.aliases = [
   'cloudmanager:get-execution-step-log',
 ]
 
+GetExecutionStepLogs.permissionInfo = {}
+
 module.exports = GetExecutionStepLogs

--- a/src/commands/cloudmanager/execution/tail-step-log.js
+++ b/src/commands/cloudmanager/execution/tail-step-log.js
@@ -53,4 +53,6 @@ TailExecutionStepLog.args = [
   },
 ]
 
+TailExecutionStepLog.permissionInfo = {}
+
 module.exports = TailExecutionStepLog

--- a/src/commands/cloudmanager/ip-allowlist/bind.js
+++ b/src/commands/cloudmanager/ip-allowlist/bind.js
@@ -52,4 +52,8 @@ BindIPAllowlist.flags = {
   ...commonFlags.programId,
 }
 
+BindIPAllowlist.permissionInfo = {
+  operation: 'createIPAllowlistBinding',
+}
+
 module.exports = BindIPAllowlist

--- a/src/commands/cloudmanager/ip-allowlist/create.js
+++ b/src/commands/cloudmanager/ip-allowlist/create.js
@@ -54,4 +54,8 @@ CreateIPAllowlist.flags = {
   }),
 }
 
+CreateIPAllowlist.permissionInfo = {
+  operation: 'createIPAllowlist',
+}
+
 module.exports = CreateIPAllowlist

--- a/src/commands/cloudmanager/ip-allowlist/delete.js
+++ b/src/commands/cloudmanager/ip-allowlist/delete.js
@@ -49,4 +49,8 @@ DeleteIPAllowlist.flags = {
   ...commonFlags.programId,
 }
 
+DeleteIPAllowlist.permissionInfo = {
+  operation: 'deleteIPAllowlist',
+}
+
 module.exports = DeleteIPAllowlist

--- a/src/commands/cloudmanager/ip-allowlist/get-binding-details.js
+++ b/src/commands/cloudmanager/ip-allowlist/get-binding-details.js
@@ -89,4 +89,6 @@ ListIPAllowlistBindingDetails.flags = {
   ...commonFlags.programId,
 }
 
+ListIPAllowlistBindingDetails.permissionInfo = {}
+
 module.exports = ListIPAllowlistBindingDetails

--- a/src/commands/cloudmanager/ip-allowlist/unbind.js
+++ b/src/commands/cloudmanager/ip-allowlist/unbind.js
@@ -52,4 +52,8 @@ UnbindIPAllowlist.flags = {
   ...commonFlags.programId,
 }
 
+UnbindIPAllowlist.permissionInfo = {
+  operation: 'deleteIPAllowlistBinding',
+}
+
 module.exports = UnbindIPAllowlist

--- a/src/commands/cloudmanager/ip-allowlist/update.js
+++ b/src/commands/cloudmanager/ip-allowlist/update.js
@@ -57,4 +57,8 @@ UpdateIPAllowlist.flags = {
   }),
 }
 
+UpdateIPAllowlist.permissionInfo = {
+  operation: 'updateIPAllowlist',
+}
+
 module.exports = UpdateIPAllowlist

--- a/src/commands/cloudmanager/list-programs.js
+++ b/src/commands/cloudmanager/list-programs.js
@@ -53,4 +53,6 @@ ListProgramsCommand.flags = {
   enabledonly: flags.boolean({ char: 'e', description: 'only output Cloud Manager-enabled programs' }),
 }
 
+ListProgramsCommand.permissionInfo = {}
+
 module.exports = ListProgramsCommand

--- a/src/commands/cloudmanager/pipeline/create-execution.js
+++ b/src/commands/cloudmanager/pipeline/create-execution.js
@@ -49,4 +49,8 @@ StartExecutionCommand.args = [
 
 StartExecutionCommand.aliases = ['cloudmanager:create-execution', 'cloudmanager:start-execution']
 
+StartExecutionCommand.permissionInfo = {
+  operation: 'startPipeline',
+}
+
 module.exports = StartExecutionCommand

--- a/src/commands/cloudmanager/pipeline/delete.js
+++ b/src/commands/cloudmanager/pipeline/delete.js
@@ -51,4 +51,8 @@ DeletePipelineCommand.aliases = [
   'cloudmanager:delete-pipeline',
 ]
 
+DeletePipelineCommand.permissionInfo = {
+  operation: 'deletePipeline',
+}
+
 module.exports = DeletePipelineCommand

--- a/src/commands/cloudmanager/pipeline/invalidate-cache.js
+++ b/src/commands/cloudmanager/pipeline/invalidate-cache.js
@@ -47,4 +47,8 @@ InvalidatePipelineCacheCommand.args = [
   { name: 'pipelineId', required: true, description: 'the pipeline id' },
 ]
 
+InvalidatePipelineCacheCommand.permissionInfo = {
+  operation: 'invalidateCache',
+}
+
 module.exports = InvalidatePipelineCacheCommand

--- a/src/commands/cloudmanager/pipeline/list-executions.js
+++ b/src/commands/cloudmanager/pipeline/list-executions.js
@@ -49,4 +49,6 @@ ListExecutionsCommand.args = [
   { name: 'pipelineId', required: true, description: 'the pipeline id' },
 ]
 
+ListExecutionsCommand.permissionInfo = {}
+
 module.exports = ListExecutionsCommand

--- a/src/commands/cloudmanager/pipeline/list-variables.js
+++ b/src/commands/cloudmanager/pipeline/list-variables.js
@@ -45,4 +45,8 @@ ListPipelineVariablesCommand.aliases = [
   'cloudmanager:list-pipeline-variables',
 ]
 
+ListPipelineVariablesCommand.permissionInfo = {
+  operation: 'getPipelineVariables',
+}
+
 module.exports = ListPipelineVariablesCommand

--- a/src/commands/cloudmanager/pipeline/set-variables.js
+++ b/src/commands/cloudmanager/pipeline/set-variables.js
@@ -44,4 +44,8 @@ SetPipelineVariablesCommand.aliases = [
   'cloudmanager:set-pipeline-variables',
 ]
 
+SetPipelineVariablesCommand.permissionInfo = {
+  operation: 'patchPipelineVariables',
+}
+
 module.exports = SetPipelineVariablesCommand

--- a/src/commands/cloudmanager/pipeline/update.js
+++ b/src/commands/cloudmanager/pipeline/update.js
@@ -68,4 +68,8 @@ UpdatePipelineCommand.aliases = [
   'cloudmanager:update-pipeline',
 ]
 
+UpdatePipelineCommand.permissionInfo = {
+  operation: 'patchPipeline',
+}
+
 module.exports = UpdatePipelineCommand

--- a/src/commands/cloudmanager/program/delete.js
+++ b/src/commands/cloudmanager/program/delete.js
@@ -48,4 +48,8 @@ DeleteProgramCommand.aliases = [
   'cloudmanager:delete-program',
 ]
 
+DeleteProgramCommand.permissionInfo = {
+  operation: 'deleteProgram',
+}
+
 module.exports = DeleteProgramCommand

--- a/src/commands/cloudmanager/program/list-current-executions.js
+++ b/src/commands/cloudmanager/program/list-current-executions.js
@@ -48,4 +48,6 @@ ListCurrentExecutionsCommand.aliases = [
   'cloudmanager:list-current-executions',
 ]
 
+ListCurrentExecutionsCommand.permissionInfo = {}
+
 module.exports = ListCurrentExecutionsCommand

--- a/src/commands/cloudmanager/program/list-environments.js
+++ b/src/commands/cloudmanager/program/list-environments.js
@@ -59,4 +59,6 @@ ListEnvironmentsCommand.aliases = [
   'cloudmanager:list-environments',
 ]
 
+ListEnvironmentsCommand.permissionInfo = {}
+
 module.exports = ListEnvironmentsCommand

--- a/src/commands/cloudmanager/program/list-ip-allowlists.js
+++ b/src/commands/cloudmanager/program/list-ip-allowlists.js
@@ -87,4 +87,6 @@ ListIPAllowlists.flags = {
   ...commonFlags.programId,
 }
 
+ListIPAllowlists.permissionInfo = {}
+
 module.exports = ListIPAllowlists

--- a/src/commands/cloudmanager/program/list-pipelines.js
+++ b/src/commands/cloudmanager/program/list-pipelines.js
@@ -55,4 +55,6 @@ ListPipelinesCommand.aliases = [
   'cloudmanager:list-pipelines',
 ]
 
+ListPipelinesCommand.permissionInfo = {}
+
 module.exports = ListPipelinesCommand

--- a/src/hooks/init/load-permission-info.js
+++ b/src/hooks/init/load-permission-info.js
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const fetch = require('node-fetch')
+const { isThisPlugin, isPermissionsRequest } = require('../../cloudmanager-hook-helpers')
+
+module.exports = (hookOptions) => {
+  if (isThisPlugin(hookOptions) && isPermissionsRequest(hookOptions)) {
+    return new Promise((resolve, reject) => {
+      fetch('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json').then(response => {
+        if (response.ok) {
+          response.json().then(json => {
+            hookOptions.config.permissionData = json
+            resolve()
+          }).catch(() => resolve())
+        } else {
+          resolve()
+        }
+      }).catch(() => resolve())
+    })
+  }
+}

--- a/src/hooks/prerun/permission-info.js
+++ b/src/hooks/prerun/permission-info.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { isThisPlugin, isPermissionsRequest } = require('../../cloudmanager-hook-helpers')
+
+module.exports = function (hookOptions) {
+  if (!isThisPlugin(hookOptions)) {
+    return
+  }
+
+  if (isPermissionsRequest(hookOptions)) {
+    const permissionInfo = hookOptions.Command.permissionInfo
+    if (!permissionInfo) {
+      this.warn(`No permission information available for ${hookOptions.Command.id}.`)
+    } else if (!permissionInfo.operation) {
+      this.log(`${hookOptions.Command.id} does not require any specific permissions.`)
+    } else if (!hookOptions.config.permissionData) {
+      this.warn(`Permission data not loaded. Unable to identify permissions for ${hookOptions.Command.id}.`)
+    } else {
+      const data = hookOptions.config.permissionData
+      const operation = permissionInfo.operation
+      const info = data.find(item => item.operation === operation)
+      if (!info) {
+        this.warn(`Unknown operation ${operation} for ${hookOptions.Command.id}. Cannot list permissions required.`)
+      } else {
+        this.log(`To execute ${hookOptions.Command.id}, one of the following product profiles is required: ${info.profiles}.`)
+      }
+    }
+    this.exit()
+  }
+}

--- a/src/hooks/prerun/prerun-all.js
+++ b/src/hooks/prerun/prerun-all.js
@@ -17,6 +17,7 @@ const { handleError } = require('../../cloudmanager-helpers')
 
 module.exports = function (hookOptions) {
   try {
+    require('./permission-info').apply(this, [hookOptions])
     require('./environment-id-from-config').apply(this, [hookOptions])
     require('./check-ims-context-config').apply(this, [hookOptions])
   } catch (err) {

--- a/test/hooks/init/load-permission-info.test.js
+++ b/test/hooks/init/load-permission-info.test.js
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const fetchMock = require('fetch-mock').sandbox()
+jest.setMock('node-fetch', fetchMock)
+
+const hook = require('../../../src/hooks/init/load-permission-info')
+
+afterEach(() => {
+  fetchMock.reset()
+})
+
+test('load permission info -- empty config results in no fetch', async () => {
+  await hook()
+  expect(fetchMock.calls(true).length).toBe(0)
+})
+
+test('load permission info -- other id results in no fetch', async () => {
+  await hook({
+    id: 'somethingelse',
+  })
+  expect(fetchMock.calls(true).length).toBe(0)
+})
+
+test('load permission info -- correct id but empty argv no fetch', async () => {
+  await hook({
+    id: 'cloudmanager:something',
+    argv: [],
+  })
+  expect(fetchMock.calls(true).length).toBe(0)
+})
+
+test('load permission info -- correct id fetches', async () => {
+  fetchMock.mock('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json', [
+    {
+      operation: 'test-operation',
+    },
+  ])
+  const hookOptions = {
+    id: 'cloudmanager:something',
+    argv: ['--permissions'],
+    config: {},
+  }
+  await hook(hookOptions)
+  expect(fetchMock.calls(true).length).toBe(1)
+  expect(fetchMock.calls('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json').length).toBe(1)
+  expect(hookOptions.config.permissionData).toBeTruthy()
+  expect(hookOptions.config.permissionData.length).toBe(1)
+  expect(hookOptions.config.permissionData).toEqual(expect.arrayContaining([
+    {
+      operation: 'test-operation',
+    },
+  ]))
+})
+
+test('load permission info -- wrong response type', async () => {
+  fetchMock.mock('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json', "some text that isn't json")
+  const hookOptions = {
+    id: 'cloudmanager:something',
+    argv: ['--permissions'],
+    config: {},
+  }
+  await hook(hookOptions)
+  expect(fetchMock.calls(true).length).toBe(1)
+  expect(fetchMock.calls('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json').length).toBe(1)
+  expect(hookOptions.config.permissionData).toBeUndefined()
+})
+
+test('load permission info -- error response', async () => {
+  fetchMock.mock('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json', 500)
+  const hookOptions = {
+    id: 'cloudmanager:something',
+    argv: ['--permissions'],
+    config: {},
+  }
+  await hook(hookOptions)
+  expect(fetchMock.calls(true).length).toBe(1)
+  expect(fetchMock.calls('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json').length).toBe(1)
+  expect(hookOptions.config.permissionData).toBeUndefined()
+})
+
+test('load permission info -- fetch throwing', async () => {
+  fetchMock.mock('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json', {
+    throws: new Error(),
+  })
+  const hookOptions = {
+    id: 'cloudmanager:something',
+    argv: ['--permissions'],
+    config: {},
+  }
+  await hook(hookOptions)
+  expect(fetchMock.calls(true).length).toBe(1)
+  expect(fetchMock.calls('https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/src/data/permissions.json').length).toBe(1)
+  expect(hookOptions.config.permissionData).toBeUndefined()
+})

--- a/test/hooks/prerun/permission-info.test.js
+++ b/test/hooks/prerun/permission-info.test.js
@@ -1,0 +1,136 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const hook = require('../../../src/hooks/prerun/permission-info')
+
+let exit
+let warn
+let log
+
+beforeEach(() => {
+  exit = jest.fn()
+  warn = jest.fn()
+  log = jest.fn()
+})
+
+const invoke = (options) => {
+  return () => hook.apply({ exit, warn, log }, [{
+    Command: Fixture,
+    config: {},
+    ...options,
+  }])
+}
+
+test('hook -- command from other plugin', async () => {
+  expect(invoke({
+    Command: FixtureFromOtherPlugin,
+    argv: [],
+  })).not.toThrowError()
+})
+
+test("hook -- no argv doesn't call exit", async () => {
+  invoke({
+    argv: [],
+  })()
+  expect(exit.mock.calls.length).toBe(0)
+})
+
+test("hook -- some other argv doesn't call exit", async () => {
+  invoke({
+    argv: ['--environmentId=3'],
+  })()
+  expect(exit.mock.calls.length).toBe(0)
+})
+
+test('hook -- permissions missing', async () => {
+  invoke({
+    argv: ['--permissions'],
+  })()
+  expect(exit.mock.calls.length).toBe(1)
+  expect(warn.mock.calls[0][0]).toBe('No permission information available for somecommand.')
+})
+
+test('hook -- permissions empty', async () => {
+  invoke({
+    Command: FixtureWithEmptyPermissions,
+    argv: ['--permissions'],
+  })()
+  expect(exit.mock.calls.length).toBe(1)
+  expect(log.mock.calls[0][0]).toBe('somecommand2 does not require any specific permissions.')
+})
+
+test('hook -- operation defined but no data', async () => {
+  invoke({
+    Command: FixtureWithAnOperation,
+    argv: ['--permissions'],
+  })()
+  expect(exit.mock.calls.length).toBe(1)
+  expect(warn.mock.calls[0][0]).toBe('Permission data not loaded. Unable to identify permissions for somecommand3.')
+})
+
+test('hook -- operation defined but not found', async () => {
+  invoke({
+    Command: FixtureWithAnOperation,
+    argv: ['--permissions'],
+    config: {
+      permissionData: [],
+    },
+  })()
+  expect(exit.mock.calls.length).toBe(1)
+  expect(warn.mock.calls[0][0]).toBe('Unknown operation someoperation for somecommand3. Cannot list permissions required.')
+})
+
+test('hook -- operation defined and found', async () => {
+  invoke({
+    Command: FixtureWithAnOperation,
+    argv: ['--permissions'],
+    config: {
+      permissionData: [{
+        operation: 'someoperation',
+        profiles: 'Profile1, Profile2',
+      }],
+    },
+  })()
+  expect(exit.mock.calls.length).toBe(1)
+  expect(log.mock.calls[0][0]).toBe('To execute somecommand3, one of the following product profiles is required: Profile1, Profile2.')
+})
+
+class Fixture {
+}
+Fixture.id = 'somecommand'
+Fixture.plugin = {
+  name: '@adobe/aio-cli-plugin-cloudmanager',
+}
+
+class FixtureWithEmptyPermissions {
+}
+FixtureWithEmptyPermissions.id = 'somecommand2'
+FixtureWithEmptyPermissions.plugin = {
+  name: '@adobe/aio-cli-plugin-cloudmanager',
+}
+FixtureWithEmptyPermissions.permissionInfo = {}
+
+class FixtureWithAnOperation {
+}
+FixtureWithAnOperation.id = 'somecommand3'
+FixtureWithAnOperation.plugin = {
+  name: '@adobe/aio-cli-plugin-cloudmanager',
+}
+FixtureWithAnOperation.permissionInfo = {
+  operation: 'someoperation',
+}
+
+class FixtureFromOtherPlugin {
+}
+FixtureFromOtherPlugin.plugin = {
+  name: 'something-else',
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a "virtual" flag `--permissions` to commands to output relevant permissions info.

## Related Issue

#175

## Motivation and Context

Enables users to discover permission data without reading

## How Has This Been Tested?

Unit tests
Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
