### PR TITLE
feat(commerce): args fixes #489

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@commitlint/config-conventional": "13.1.0",
     "@oclif/dev-cli": "1.26.0",
     "@semantic-release/changelog": "5.0.1",
-    "@semantic-release/git": "9.0.1",
+    "@semantic-release/git": "10.0.0",
     "chalk": "4.1.2",
     "codecov": "3.8.3",
     "eslint": "7.32.0",

--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -296,6 +296,16 @@ function handleError (_error, errorFn) {
   })
 }
 
+function getFormattedFlags (flags) {
+  return Object.keys(flags).filter(flag => flag !== 'programId').map(flag => {
+    if (flags[flag]) {
+      return `--${flag}`
+    } else {
+      return `--no-${flag}`
+    }
+  })
+}
+
 module.exports = {
   getProgramId,
   getOutputFormat,
@@ -318,4 +328,5 @@ module.exports = {
   getActiveOrganizationId,
   getFullOrgIdentity,
   handleError,
+  getFormattedFlags,
 }

--- a/src/commands/cloudmanager/commerce/bin-magento/app/config/dump.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/app/config/dump.js
@@ -11,9 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../../common-flags')
 const commonArgs = require('../../../../../../common-args')
+const commonCommerceFlags = require('../../../../../../common-commerce-flags')
 
 class AppConfigDumpCommand extends BaseCommerceCliCommand {
   async run () {
@@ -26,7 +27,7 @@ class AppConfigDumpCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'app:config:dump',
-        options: ['-n', ...configTypes],
+        options: ['-n', ...configTypes, ...getFormattedFlags(flags)],
       },
       1000, 'app:config:dump')
 
@@ -41,6 +42,10 @@ AppConfigDumpCommand.description = 'commerce config dump'
 AppConfigDumpCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 AppConfigDumpCommand.args = [

--- a/src/commands/cloudmanager/commerce/bin-magento/app/config/import.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/app/config/import.js
@@ -11,9 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../../common-flags')
 const commonArgs = require('../../../../../../common-args')
+const commonCommerceFlags = require('../../../../../../common-commerce-flags')
 
 class AppConfigImportCommand extends BaseCommerceCliCommand {
   async run () {
@@ -25,7 +26,7 @@ class AppConfigImportCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'app:config:import',
-        options: ['-n'],
+        options: ['-n', ...getFormattedFlags(flags)],
       },
       1000, 'app:config:import')
 
@@ -38,6 +39,10 @@ AppConfigImportCommand.description = 'commerce config import'
 AppConfigImportCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 AppConfigImportCommand.args = [

--- a/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
@@ -14,23 +14,28 @@ const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command
 const { getProgramId } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
 const commonArgs = require('../../../../../common-args')
+const commonCommerceArgs = require('../../../../../common-commerce-args')
 
 class CacheCleanCommand extends BaseCommerceCliCommand {
   async run () {
     const { args, flags } = this.parse(CacheCleanCommand)
 
     const programId = getProgramId(flags)
+    const cacheTypes = args.slice(1)
 
     const result = await this.runSync(programId, args.environmentId,
       {
         type: 'bin/magento',
         command: 'cache:clean',
+        options: ['-n', ...cacheTypes],
       },
       1000, 'cache:clean')
 
     return result
   }
 }
+
+CacheCleanCommand.strict = false
 
 CacheCleanCommand.description = 'commerce cache clean'
 
@@ -41,6 +46,7 @@ CacheCleanCommand.flags = {
 
 CacheCleanCommand.args = [
   commonArgs.environmentId,
+  commonCommerceArgs.cacheType,
 ]
 
 CacheCleanCommand.aliases = [

--- a/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
@@ -11,23 +11,24 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
 const commonArgs = require('../../../../../common-args')
+const commonCommerceFlags = require('../../../../../common-commerce-flags')
 const commonCommerceArgs = require('../../../../../common-commerce-args')
 
 class CacheCleanCommand extends BaseCommerceCliCommand {
   async run () {
-    const { args, flags } = this.parse(CacheCleanCommand)
+    const { args, flags, argv } = this.parse(CacheCleanCommand)
 
     const programId = getProgramId(flags)
-    const cacheTypes = args.slice(1)
+    const cacheTypes = argv.slice(1)
 
     const result = await this.runSync(programId, args.environmentId,
       {
         type: 'bin/magento',
         command: 'cache:clean',
-        options: ['-n', ...cacheTypes],
+        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags)],
       },
       1000, 'cache:clean')
 
@@ -42,6 +43,10 @@ CacheCleanCommand.description = 'commerce cache clean'
 CacheCleanCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 CacheCleanCommand.args = [

--- a/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
@@ -11,23 +11,24 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
 const commonArgs = require('../../../../../common-args')
+const commonCommerceFlags = require('../../../../../common-commerce-flags')
 const commonCommerceArgs = require('../../../../../common-commerce-args')
 
 class CacheFlushCommand extends BaseCommerceCliCommand {
   async run () {
-    const { args, flags } = this.parse(CacheFlushCommand)
+    const { args, flags, argv } = this.parse(CacheFlushCommand)
 
     const programId = getProgramId(flags)
-    const cacheTypes = args.slice(1)
+    const cacheTypes = argv.slice(1)
 
     const result = await this.runSync(programId, args.environmentId,
       {
         type: 'bin/magento',
         command: 'cache:flush',
-        options: ['-n', ...cacheTypes]
+        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags)],
       },
       1000, 'cache:flush')
 
@@ -42,6 +43,10 @@ CacheFlushCommand.description = 'commerce cache flush'
 CacheFlushCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 CacheFlushCommand.args = [

--- a/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
@@ -14,23 +14,28 @@ const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command
 const { getProgramId } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
 const commonArgs = require('../../../../../common-args')
+const commonCommerceArgs = require('../../../../../common-commerce-args')
 
 class CacheFlushCommand extends BaseCommerceCliCommand {
   async run () {
     const { args, flags } = this.parse(CacheFlushCommand)
 
     const programId = getProgramId(flags)
+    const cacheTypes = args.slice(1)
 
     const result = await this.runSync(programId, args.environmentId,
       {
         type: 'bin/magento',
         command: 'cache:flush',
+        options: ['-n', ...cacheTypes]
       },
       1000, 'cache:flush')
 
     return result
   }
 }
+
+CacheFlushCommand.strict = false
 
 CacheFlushCommand.description = 'commerce cache flush'
 
@@ -41,6 +46,7 @@ CacheFlushCommand.flags = {
 
 CacheFlushCommand.args = [
   commonArgs.environmentId,
+  commonCommerceArgs.cacheType,
 ]
 
 CacheFlushCommand.aliases = [

--- a/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
@@ -14,23 +14,28 @@ const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command
 const { getProgramId } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
 const commonArgs = require('../../../../../common-args')
+const commonCommerceArgs = require('../../../../../common-commerce-args')
 
 class IndexerReindexCommand extends BaseCommerceCliCommand {
   async run () {
     const { args, flags } = this.parse(IndexerReindexCommand)
 
     const programId = getProgramId(flags)
+    const indexTypes = args.slice(1)
 
     const result = await this.runSync(programId, args.environmentId,
       {
         type: 'bin/magento',
         command: 'indexer:reindex',
+        options: ['-n', ...indexTypes]
       },
       1000, 'indexer:reindex')
 
     return result
   }
 }
+
+IndexerReindexCommand.strict = false
 
 IndexerReindexCommand.description = 'commerce indexer reindex'
 
@@ -41,6 +46,7 @@ IndexerReindexCommand.flags = {
 
 IndexerReindexCommand.args = [
   commonArgs.environmentId,
+  commonCommerceArgs.indexType,
 ]
 
 IndexerReindexCommand.aliases = [

--- a/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
@@ -11,23 +11,24 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
 const commonArgs = require('../../../../../common-args')
+const commonCommerceFlags = require('../../../../../common-commerce-flags')
 const commonCommerceArgs = require('../../../../../common-commerce-args')
 
 class IndexerReindexCommand extends BaseCommerceCliCommand {
   async run () {
-    const { args, flags } = this.parse(IndexerReindexCommand)
+    const { args, flags, argv } = this.parse(IndexerReindexCommand)
 
     const programId = getProgramId(flags)
-    const indexTypes = args.slice(1)
+    const indexTypes = argv.slice(1)
 
     const result = await this.runSync(programId, args.environmentId,
       {
         type: 'bin/magento',
         command: 'indexer:reindex',
-        options: ['-n', ...indexTypes]
+        options: ['-n', ...indexTypes, ...getFormattedFlags(flags)],
       },
       1000, 'indexer:reindex')
 
@@ -42,6 +43,10 @@ IndexerReindexCommand.description = 'commerce indexer reindex'
 IndexerReindexCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 IndexerReindexCommand.args = [

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/disable.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/disable.js
@@ -11,8 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
+const commonCommerceFlags = require('../../../../../common-commerce-flags')
 const commonArgs = require('../../../../../common-args')
 
 class MaintenanceDisableCommand extends BaseCommerceCliCommand {
@@ -25,6 +26,7 @@ class MaintenanceDisableCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'maintenance:disable',
+        options: [...getFormattedFlags(flags)],
       },
       1000, 'maintenance:disable')
 
@@ -37,6 +39,10 @@ MaintenanceDisableCommand.description = 'commerce maintenance disable'
 MaintenanceDisableCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 MaintenanceDisableCommand.args = [

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/enable.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/enable.js
@@ -11,8 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
+const commonCommerceFlags = require('../../../../../common-commerce-flags')
 const commonArgs = require('../../../../../common-args')
 
 class MaintenanceEnableCommand extends BaseCommerceCliCommand {
@@ -25,6 +26,7 @@ class MaintenanceEnableCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'maintenance:enable',
+        options: [...getFormattedFlags(flags)],
       },
       1000, 'maintenance:enable')
 
@@ -37,6 +39,10 @@ MaintenanceEnableCommand.description = 'commerce maintenance enable'
 MaintenanceEnableCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 MaintenanceEnableCommand.args = [

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
@@ -11,8 +11,9 @@ governing permissions and limitations under the License.
 */
 
 const BaseCommerceCliCommand = require('../../../../../base-commerce-cli-command')
-const { getProgramId } = require('../../../../../cloudmanager-helpers')
+const { getProgramId, getFormattedFlags } = require('../../../../../cloudmanager-helpers')
 const commonFlags = require('../../../../../common-flags')
+const commonCommerceFlags = require('../../../../../common-commerce-flags')
 const commonArgs = require('../../../../../common-args')
 
 class MaintenanceStatusCommand extends BaseCommerceCliCommand {
@@ -25,6 +26,7 @@ class MaintenanceStatusCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'maintenance:status',
+        options: [...getFormattedFlags(flags)],
       },
       1000, 'maintenance:status')
 
@@ -37,6 +39,10 @@ MaintenanceStatusCommand.description = 'commerce maintenance status'
 MaintenanceStatusCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  ...commonCommerceFlags.quiet,
+  ...commonCommerceFlags.verbose,
+  ...commonCommerceFlags.version,
+  ...commonCommerceFlags.ansi,
 }
 
 MaintenanceStatusCommand.args = [

--- a/src/common-commerce-args.js
+++ b/src/common-commerce-args.js
@@ -1,0 +1,16 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports = {
+  cacheType: { name: 'cacheType', required: false, description: 'the cache type' },
+  indexType: { name: 'indexType', required: false, description: 'the index type'}
+}

--- a/src/common-commerce-flags.js
+++ b/src/common-commerce-flags.js
@@ -9,8 +9,25 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+const { flags } = require('@oclif/command')
 
 module.exports = {
-  cacheType: { name: 'cacheType', required: false, description: 'the cache type' },
-  indexType: { name: 'indexType', required: false, description: 'the index type' },
+  global: {
+    imsContextName: flags.string({ description: 'the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager' }),
+  },
+  programId: {
+    programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" }),
+  },
+  quiet: {
+    quiet: flags.boolean({ char: 'q' }),
+  },
+  verbose: {
+    verbose: flags.boolean({ char: 'v' }),
+  },
+  version: {
+    version: flags.boolean({ char: 'V' }),
+  },
+  ansi: {
+    ansi: flags.boolean({ allowNo: true }),
+  },
 }

--- a/test/commands/commerce/bin-magento/app/config/dump.test.js
+++ b/test/commands/commerce/bin-magento/app/config/dump.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const AppConfigDumpCommand = require('../../../../../../src/commands/cloudmanager/commerce/bin-magento/app/config/dump')
@@ -73,7 +72,7 @@ test('app:config:dump - success with config types', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = AppConfigDumpCommand.run(['--programId', '3', '60', 'i18n', 'scopes'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -93,10 +92,6 @@ test('app:config:dump - success with config types', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('3', '60', '6000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting app:config:dump')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting app:config:dump')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running app:config:dump')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('done')
 })
 
 test('app:config:dump - success without config types', async () => {
@@ -126,7 +121,7 @@ test('app:config:dump - success without config types', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = AppConfigDumpCommand.run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -146,8 +141,4 @@ test('app:config:dump - success without config types', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('3', '60', '6000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting app:config:dump')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting app:config:dump')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running app:config:dump')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('done')
 })

--- a/test/commands/commerce/bin-magento/app/config/dump.test.js
+++ b/test/commands/commerce/bin-magento/app/config/dump.test.js
@@ -74,7 +74,7 @@ test('app:config:dump - success with config types', async () => {
 
   expect.assertions(7)
 
-  const runResult = AppConfigDumpCommand.run(['--programId', '3', '60', 'i18n', 'scopes'])
+  const runResult = AppConfigDumpCommand.run(['--programId', '3', '60', 'i18n', 'scopes', '-q'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -88,7 +88,7 @@ test('app:config:dump - success with config types', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('3', '60', {
     type: 'bin/magento',
     command: 'app:config:dump',
-    options: ['-n', 'i18n', 'scopes'],
+    options: ['-n', 'i18n', 'scopes', '--quiet'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('3', '60', '6000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/app/config/import.test.js
+++ b/test/commands/commerce/bin-magento/app/config/import.test.js
@@ -74,7 +74,7 @@ test('app:config:import - success', async () => {
 
   expect.assertions(7)
 
-  const runResult = AppConfigImportCommand.run(['--programId', '3', '60'])
+  const runResult = AppConfigImportCommand.run(['--programId', '3', '60', '-v'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -88,7 +88,7 @@ test('app:config:import - success', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('3', '60', {
     type: 'bin/magento',
     command: 'app:config:import',
-    options: ['-n'],
+    options: ['-n', '--verbose'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('3', '60', '6000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/app/config/import.test.js
+++ b/test/commands/commerce/bin-magento/app/config/import.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const AppConfigImportCommand = require('../../../../../../src/commands/cloudmanager/commerce/bin-magento/app/config/import')
@@ -73,7 +72,7 @@ test('app:config:import - success', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = AppConfigImportCommand.run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -93,8 +92,4 @@ test('app:config:import - success', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('3', '60', '6000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting app:config:import')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting app:config:import')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running app:config:import')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('done')
 })

--- a/test/commands/commerce/bin-magento/cache/clean.test.js
+++ b/test/commands/commerce/bin-magento/cache/clean.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const CacheCleanCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/cache/clean')
@@ -62,7 +61,7 @@ test('maintenance:status', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = CacheCleanCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -81,10 +80,6 @@ test('maintenance:status', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting cache:clean')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting cache:clean')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running cache:clean')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('done')
 })
 
 test('cache:clean - api error', async () => {

--- a/test/commands/commerce/bin-magento/cache/clean.test.js
+++ b/test/commands/commerce/bin-magento/cache/clean.test.js
@@ -63,7 +63,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(7)
 
-  const runResult = CacheCleanCommand.run(['--programId', '5', '10'])
+  const runResult = CacheCleanCommand.run(['--programId', '5', '10', '-V', '--ansi'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -77,6 +77,7 @@ test('maintenance:status', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'cache:clean',
+    options: ['-n', '--version', '--ansi'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/cache/flush.test.js
+++ b/test/commands/commerce/bin-magento/cache/flush.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const CacheFlushCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/cache/flush')
@@ -62,7 +61,7 @@ test('maintenance:status', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = CacheFlushCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -81,10 +80,6 @@ test('maintenance:status', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting cache:flush')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting cache:flush')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running cache:flush')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('done')
 })
 
 test('cache:flush - api error', async () => {

--- a/test/commands/commerce/bin-magento/cache/flush.test.js
+++ b/test/commands/commerce/bin-magento/cache/flush.test.js
@@ -63,7 +63,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(7)
 
-  const runResult = CacheFlushCommand.run(['--programId', '5', '10'])
+  const runResult = CacheFlushCommand.run(['--programId', '5', '10', '--no-ansi'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -77,6 +77,7 @@ test('maintenance:status', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'cache:flush',
+    options: ['-n', '--no-ansi'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/indexer/reindex.test.js
+++ b/test/commands/commerce/bin-magento/indexer/reindex.test.js
@@ -77,6 +77,7 @@ test('maintenance:status', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'indexer:reindex',
+    options: ['-n'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/indexer/reindex.test.js
+++ b/test/commands/commerce/bin-magento/indexer/reindex.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const IndexerReindexCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/indexer/reindex')
@@ -62,7 +61,7 @@ test('maintenance:status', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = IndexerReindexCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -81,10 +80,6 @@ test('maintenance:status', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting indexer:reindex')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting indexer:reindex')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running indexer:reindex')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('done')
 })
 
 test('indexer:reindex - api error', async () => {

--- a/test/commands/commerce/bin-magento/maintenance/disable.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/disable.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const MaintenanceDisableCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/disable')
@@ -62,7 +61,7 @@ test('maintenance:disable', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = MaintenanceDisableCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -81,10 +80,6 @@ test('maintenance:disable', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting maintenance:disable')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting maintenance:disable')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running maintenance:disable')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('maintenance disabled')
 })
 
 test('maintenance:disable - api error', async () => {

--- a/test/commands/commerce/bin-magento/maintenance/disable.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/disable.test.js
@@ -77,6 +77,7 @@ test('maintenance:disable', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'maintenance:disable',
+    options: [],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/maintenance/enable.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/enable.test.js
@@ -77,6 +77,7 @@ test('maintenance:enable', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'maintenance:enable',
+    options: [],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/maintenance/enable.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/enable.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const MaintenanceEnableCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/enable')
@@ -62,7 +61,7 @@ test('maintenance:enable', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = MaintenanceEnableCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -81,10 +80,6 @@ test('maintenance:enable', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting maintenance:enable')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting maintenance:enable')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running maintenance:enable')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('maintenance enabled')
 })
 
 test('maintenance:enable - api error', async () => {

--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { cli } = require('cli-ux')
 const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const MaintenanceStatusCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/status')
@@ -62,7 +61,7 @@ test('maintenance:status', async () => {
     })
   })
 
-  expect.assertions(11)
+  expect.assertions(7)
 
   const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
@@ -81,10 +80,6 @@ test('maintenance:status', async () => {
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)
-  await expect(cli.action.start.mock.calls[0][0]).toEqual('Starting maintenance:status')
-  await expect(cli.action.start.mock.calls[1][0]).toEqual('Starting maintenance:status')
-  await expect(cli.action.start.mock.calls[2][0]).toEqual('Running maintenance:status')
-  await expect(cli.action.stop.mock.calls[0][0]).toEqual('maintenance enabled')
 })
 
 test('maintenance:status - api error', async () => {

--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -77,6 +77,7 @@ test('maintenance:status', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'maintenance:status',
+    options: [],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
All relevant commerce commands can now handle the optional args and flags as defined by devdocs: https://devdocs.magento.com/guides/v2.4/reference/cli/magento.html#maintenanceenable

## Description

<!--- Describe your changes in detail -->
* cache:clean, cache:flush, and reindex can now handle their optional args
* all commerce commands can pass common commerce flags
* updated unit tests

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
