### PR TITLE
chore(test): clean up test output by mocking info/warn

### DIFF
--- a/test/commands/commerce/bin-magento/app/config/dump.test.js
+++ b/test/commands/commerce/bin-magento/app/config/dump.test.js
@@ -15,14 +15,25 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const AppConfigDumpCommand = require('../../../../../../src/commands/cloudmanager/commerce/bin-magento/app/config/dump')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
 
+const run = (argv) => {
+  const cmd = new AppConfigDumpCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 test('app:config:dump - missing environmentId', async () => {
   expect.assertions(2)
 
-  const runResult = AppConfigDumpCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +41,7 @@ test('app:config:dump - missing environmentId', async () => {
 test('app:config:dump - missing IMS Context', async () => {
   expect.assertions(2)
 
-  const runResult = AppConfigDumpCommand.run(['--programId', '3', '60'])
+  const runResult = run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -41,7 +52,7 @@ test('app:config:dump - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = AppConfigDumpCommand.run(['--programId', '3', '60'])
+  const runResult = run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })
@@ -75,7 +86,7 @@ test('app:config:dump - success with config types', async () => {
 
   expect.assertions(11)
 
-  const runResult = AppConfigDumpCommand.run(['--programId', '3', '60', 'i18n', 'scopes'])
+  const runResult = run(['--programId', '3', '60', 'i18n', 'scopes'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -128,7 +139,7 @@ test('app:config:dump - success without config types', async () => {
 
   expect.assertions(11)
 
-  const runResult = AppConfigDumpCommand.run(['--programId', '3', '60'])
+  const runResult = run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)

--- a/test/commands/commerce/bin-magento/app/config/import.test.js
+++ b/test/commands/commerce/bin-magento/app/config/import.test.js
@@ -15,14 +15,26 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const AppConfigImportCommand = require('../../../../../../src/commands/cloudmanager/commerce/bin-magento/app/config/import')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
+
+const run = (argv) => {
+  const cmd = new AppConfigImportCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 
 test('app:config:import - missing environmentId', async () => {
   expect.assertions(2)
 
-  const runResult = AppConfigImportCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +42,7 @@ test('app:config:import - missing environmentId', async () => {
 test('app:config:import - missing IMS Context', async () => {
   expect.assertions(2)
 
-  const runResult = AppConfigImportCommand.run(['--programId', '3', '60'])
+  const runResult = run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -41,7 +53,7 @@ test('app:config:import - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = AppConfigImportCommand.run(['--programId', '3', '60'])
+  const runResult = run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })
@@ -75,7 +87,7 @@ test('app:config:import - success', async () => {
 
   expect.assertions(11)
 
-  const runResult = AppConfigImportCommand.run(['--programId', '3', '60'])
+  const runResult = run(['--programId', '3', '60'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)

--- a/test/commands/commerce/bin-magento/cache/clean.test.js
+++ b/test/commands/commerce/bin-magento/cache/clean.test.js
@@ -15,14 +15,26 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const CacheCleanCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/cache/clean')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
+
+const run = (argv) => {
+  const cmd = new CacheCleanCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 
 test('cache:clean - missing arg', async () => {
   expect.assertions(2)
 
-  const runResult = CacheCleanCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +42,7 @@ test('cache:clean - missing arg', async () => {
 test('maintenance:status - missing config', async () => {
   expect.assertions(2)
 
-  const runResult = CacheCleanCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -64,7 +76,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(11)
 
-  const runResult = CacheCleanCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -93,7 +105,7 @@ test('cache:clean - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = CacheCleanCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })

--- a/test/commands/commerce/bin-magento/cache/flush.test.js
+++ b/test/commands/commerce/bin-magento/cache/flush.test.js
@@ -15,14 +15,26 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const CacheFlushCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/cache/flush')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
+
+const run = (argv) => {
+  const cmd = new CacheFlushCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 
 test('cache:flush - missing arg', async () => {
   expect.assertions(2)
 
-  const runResult = CacheFlushCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +42,7 @@ test('cache:flush - missing arg', async () => {
 test('maintenance:status - missing config', async () => {
   expect.assertions(2)
 
-  const runResult = CacheFlushCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -64,7 +76,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(11)
 
-  const runResult = CacheFlushCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -93,7 +105,7 @@ test('cache:flush - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = CacheFlushCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })

--- a/test/commands/commerce/bin-magento/indexer/reindex.test.js
+++ b/test/commands/commerce/bin-magento/indexer/reindex.test.js
@@ -15,14 +15,26 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const IndexerReindexCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/indexer/reindex')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
+
+const run = (argv) => {
+  const cmd = new IndexerReindexCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 
 test('indexer:reindex - missing arg', async () => {
   expect.assertions(2)
 
-  const runResult = IndexerReindexCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +42,7 @@ test('indexer:reindex - missing arg', async () => {
 test('maintenance:status - missing config', async () => {
   expect.assertions(2)
 
-  const runResult = IndexerReindexCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -64,7 +76,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(11)
 
-  const runResult = IndexerReindexCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -93,7 +105,7 @@ test('indexer:reindex - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = IndexerReindexCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })

--- a/test/commands/commerce/bin-magento/maintenance/disable.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/disable.test.js
@@ -15,14 +15,26 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const MaintenanceDisableCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/disable')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
+
+const run = (argv) => {
+  const cmd = new MaintenanceDisableCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 
 test('maintenance:disable - missing arg', async () => {
   expect.assertions(2)
 
-  const runResult = MaintenanceDisableCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +42,7 @@ test('maintenance:disable - missing arg', async () => {
 test('maintenance:disable - missing config', async () => {
   expect.assertions(2)
 
-  const runResult = MaintenanceDisableCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -64,7 +76,7 @@ test('maintenance:disable', async () => {
 
   expect.assertions(11)
 
-  const runResult = MaintenanceDisableCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -93,7 +105,7 @@ test('maintenance:disable - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = MaintenanceDisableCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })

--- a/test/commands/commerce/bin-magento/maintenance/enable.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/enable.test.js
@@ -15,14 +15,26 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const MaintenanceEnableCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/enable')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
+
+const run = (argv) => {
+  const cmd = new MaintenanceEnableCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 
 test('maintenance:enable - missing arg', async () => {
   expect.assertions(2)
 
-  const runResult = MaintenanceEnableCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +42,7 @@ test('maintenance:enable - missing arg', async () => {
 test('maintenance:enable - missing config', async () => {
   expect.assertions(2)
 
-  const runResult = MaintenanceEnableCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -64,7 +76,7 @@ test('maintenance:enable', async () => {
 
   expect.assertions(11)
 
-  const runResult = MaintenanceEnableCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -93,7 +105,7 @@ test('maintenance:enable - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = MaintenanceEnableCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })

--- a/test/commands/commerce/bin-magento/maintenance/status.test.js
+++ b/test/commands/commerce/bin-magento/maintenance/status.test.js
@@ -15,14 +15,26 @@ const { init, mockSdk } = require('@adobe/aio-lib-cloudmanager')
 const { resetCurrentOrgId, setCurrentOrgId } = require('@adobe/aio-lib-ims')
 const MaintenanceStatusCommand = require('../../../../../src/commands/cloudmanager/commerce/bin-magento/maintenance/status')
 
+let warn
+let info
+
 beforeEach(() => {
   resetCurrentOrgId()
+  warn = jest.fn()
+  info = jest.fn()
 })
+
+const run = (argv) => {
+  const cmd = new MaintenanceStatusCommand(argv)
+  cmd.warn = warn
+  cmd.info = info
+  return cmd.run()
+}
 
 test('maintenance:status - missing arg', async () => {
   expect.assertions(2)
 
-  const runResult = MaintenanceStatusCommand.run([])
+  const runResult = run([])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow(/^Missing 1 required arg/)
 })
@@ -30,7 +42,7 @@ test('maintenance:status - missing arg', async () => {
 test('maintenance:status - missing config', async () => {
   expect.assertions(2)
 
-  const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
@@ -64,7 +76,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(11)
 
-  const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -93,7 +105,7 @@ test('maintenance:status - api error', async () => {
     Promise.reject(new Error('Command failed.')),
   )
   mockSdk.getCommerceCommandExecution = jest.fn()
-  const runResult = MaintenanceStatusCommand.run(['--programId', '5', '10'])
+  const runResult = run(['--programId', '5', '10'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).rejects.toEqual(new Error('Command failed.'))
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For tests that run commands that use `this.warn` or `this.info`, the log output from jest is polluted with extraneous messages. That can be avoided by mocking these methods on the command instance.

## Related Issue

n/a

## Motivation and Context

Avoid log noise in local testing and CI.

## How Has This Been Tested?

Unit tests, of course :)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
