### PR TITLE
chore(ci): add semantic-release-dry-run to ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     - run: npm version
     - run: npm install
     - run: npm test
+    - run: npm run semantic-release-dry-run
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0
       with:

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "version": "oclif-dev readme && git add README.md",
     "e2e": "jest --collectCoverage=false --testRegex './e2e/e2e.js'",
     "semantic-release": "semantic-release",
+    "semantic-release-dry-run": "semantic-release --dry-run",
     "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"


### PR DESCRIPTION
Updates to semantic-release weren't detected as problematic because semantic-release is not run during the PR build. Trying to check that...