### PR TITLE
fix: ensure that -h works for all commands. fixes #506

### DIFF
--- a/src/hooks/prerun/help-override.js
+++ b/src/hooks/prerun/help-override.js
@@ -3,28 +3,20 @@ Copyright 2021 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
 
-const { handleError } = require('../../cloudmanager-helpers')
-
-/**
- * Prerun hooks in a specific order.
- */
+const { isThisPlugin } = require('../../cloudmanager-hook-helpers')
 
 module.exports = function (hookOptions) {
-  try {
-    require('./help-override').apply(this, [hookOptions])
-    require('./permission-info').apply(this, [hookOptions])
-    require('./environment-id-from-config').apply(this, [hookOptions])
-    require('./check-ims-context-config').apply(this, [hookOptions])
-  } catch (err) {
-    if (err.code && err.code === 'EEXIT') { // code from @oclif/errors - ExitError
-      throw err
-    }
-    handleError(err, this.error)
+  if (!isThisPlugin(hookOptions)) {
+    return
+  }
+  if (hookOptions && hookOptions.argv && hookOptions.argv.includes('-h')) {
+    new hookOptions.Command(hookOptions.argv, hookOptions.config)._help()
   }
 }

--- a/test/hooks/prerun/help-override.test.js
+++ b/test/hooks/prerun/help-override.test.js
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const hook = require('../../../src/hooks/prerun/help-override')
+
+let mockHelp
+let mockConstructor
+
+beforeEach(() => {
+  mockHelp = jest.fn()
+  mockConstructor = jest.fn()
+})
+
+const invoke = (options) => {
+  return () => hook.apply({}, [{
+    Command: Fixture,
+    config: {},
+    ...options,
+  }])
+}
+
+test('hook -- command from other plugin', async () => {
+  expect(invoke({
+    Command: FixtureFromOtherPlugin,
+    argv: [],
+  })).not.toThrowError()
+})
+
+test("hook -- no argv doesn't call help", async () => {
+  invoke({
+    argv: [],
+  })()
+  expect(mockHelp.mock.calls.length).toBe(0)
+})
+
+test("hook -- some other argv doesn't call help", async () => {
+  invoke({
+    argv: ['--environmentId=3'],
+  })()
+  expect(mockHelp.mock.calls.length).toBe(0)
+})
+
+test('hook -- -h calls help', async () => {
+  invoke({
+    argv: ['-h'],
+    config: {
+      MOCKCONFIG: true,
+    },
+  })()
+  expect(mockHelp.mock.calls.length).toBe(1)
+  expect(mockConstructor.mock.calls.length).toBe(1)
+  expect(mockConstructor.mock.calls[0][0]).toEqual(['-h'])
+  expect(mockConstructor.mock.calls[0][1]).toEqual({
+    MOCKCONFIG: true,
+  })
+})
+
+class Fixture {
+  constructor (argv, config) {
+    mockConstructor(argv, config)
+  }
+
+  _help () {
+    mockHelp()
+  }
+}
+Fixture.id = 'somecommand'
+Fixture.plugin = {
+  name: '@adobe/aio-cli-plugin-cloudmanager',
+}
+
+class FixtureFromOtherPlugin {
+}
+FixtureFromOtherPlugin.plugin = {
+  name: 'something-else',
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a hook to intercept cases where `-h` is passed to commands to ensure consistent behavior

## Related Issue

#507 

## Motivation and Context

Inconsistency between strict and non-strict commands is weird -- strict isn't really something users should think about.

## How Has This Been Tested?

* Unit tests
* Manual tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
