### PR TITLE
feat(start-execution): support for emergency mode pipeline executions…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-cloudmanager/issues",
   "dependencies": {
-    "@adobe/aio-lib-cloudmanager": "^1.9.0",
+    "@adobe/aio-lib-cloudmanager": "^1.10.0",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-errors": "^3.0.1",
     "@adobe/aio-lib-core-logging": "^1.2.0",

--- a/src/commands/cloudmanager/pipeline/create-execution.js
+++ b/src/commands/cloudmanager/pipeline/create-execution.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 const { initSdk, getProgramId } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
+const { flags } = require('@oclif/command')
 const commonFlags = require('../../../common-flags')
 const BaseCommand = require('../../../base-command')
 
@@ -23,16 +24,16 @@ class StartExecutionCommand extends BaseCommand {
 
     cli.action.start('starting execution')
 
-    const result = await this.startExecution(programId, args.pipelineId, flags.imsContextName)
+    const result = await this.startExecution(programId, args.pipelineId, flags.emergency, flags.imsContextName)
 
     cli.action.stop(`started execution ID ${result.id}`)
 
     return result
   }
 
-  async startExecution (programId, pipelineId, imsContextName = null) {
+  async startExecution (programId, pipelineId, emergencyMode, imsContextName = null) {
     const sdk = await initSdk(imsContextName)
-    return sdk.createExecution(programId, pipelineId)
+    return sdk.createExecution(programId, pipelineId, emergencyMode ? 'EMERGENCY' : 'NORMAL')
   }
 }
 
@@ -41,6 +42,10 @@ StartExecutionCommand.description = 'start pipeline execution'
 StartExecutionCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
+  emergency: flags.boolean({
+    description: 'create the execution in emergency mode',
+    allowNo: true,
+  }),
 }
 
 StartExecutionCommand.args = [

--- a/test/commands/pipeline/create-execution.test.js
+++ b/test/commands/pipeline/create-execution.test.js
@@ -49,7 +49,45 @@ test('start-execution - some url', async () => {
   await expect(init.mock.calls.length).toEqual(1)
   await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.createExecution.mock.calls.length).toEqual(1)
-  await expect(mockSdk.createExecution).toHaveBeenCalledWith('5', '10')
+  await expect(mockSdk.createExecution).toHaveBeenCalledWith('5', '10', 'NORMAL')
+
+  await expect(cli.action.stop.mock.calls[0][0]).toEqual('started execution ID 5000')
+})
+
+test('start-execution - emergency', async () => {
+  setCurrentOrgId('good')
+  mockSdk.createExecution = jest.fn(() => Promise.resolve({
+    id: '5000',
+  }))
+
+  expect.assertions(6)
+
+  const runResult = StartExecutionCommand.run(['--programId', '5', '10', '--emergency'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await runResult
+  await expect(init.mock.calls.length).toEqual(1)
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(mockSdk.createExecution.mock.calls.length).toEqual(1)
+  await expect(mockSdk.createExecution).toHaveBeenCalledWith('5', '10', 'EMERGENCY')
+
+  await expect(cli.action.stop.mock.calls[0][0]).toEqual('started execution ID 5000')
+})
+
+test('start-execution - no-emergency', async () => {
+  setCurrentOrgId('good')
+  mockSdk.createExecution = jest.fn(() => Promise.resolve({
+    id: '5000',
+  }))
+
+  expect.assertions(6)
+
+  const runResult = StartExecutionCommand.run(['--programId', '5', '10', '--no-emergency'])
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await runResult
+  await expect(init.mock.calls.length).toEqual(1)
+  await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
+  await expect(mockSdk.createExecution.mock.calls.length).toEqual(1)
+  await expect(mockSdk.createExecution).toHaveBeenCalledWith('5', '10', 'NORMAL')
 
   await expect(cli.action.stop.mock.calls[0][0]).toEqual('started execution ID 5000')
 })


### PR DESCRIPTION
…. fixes #530

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add boolean `emergency` flag to `pipeline:start-execution`. If present, pass `EMERGENCY` as the mode.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#530

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
