### PR TITLE
feat(error): add request id and timestamp to error output. fixes #544

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Primarily for scripting application purposes, the following exit codes are used:
 
 ## Reporting Issues
 
-In general, issues with this plugin should be reported in this project using GitHub issues using one of the provided issue templates.
+In general, issues with this plugin should be reported in this project using GitHub issues using one of the provided issue templates. Errors emanating from the Cloud Manager API (i.e. those with exit code 30 as described above) should be reportd to Adobe support. The error output will generally contain the URL, response code, and other debug information that is necessary to identify and resolve the issue.
 
 # Commands
 <!-- commands -->

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-cloudmanager/issues",
   "dependencies": {
-    "@adobe/aio-lib-cloudmanager": "^1.10.0",
+    "@adobe/aio-lib-cloudmanager": "^1.11.0",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-errors": "^3.0.1",
     "@adobe/aio-lib-core-logging": "^1.2.0",

--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -273,9 +273,14 @@ function handleError (_error, errorFn) {
   }
 
   let exitCode = exitCodes.GENERAL
+  let reference
   switch (_error.name) {
     case 'CloudManagerError':
       exitCode = exitCodes.SDK
+      reference = `Timestamp: ${new Date().toISOString()}`
+      if (_error.sdkDetails && _error.sdkDetails.requestId) {
+        reference = `Request Id: ${_error.sdkDetails.requestId}. ${reference}`
+      }
       break
     case 'CloudManagerCLIValidationError':
       exitCode = exitCodes.VALIDATION
@@ -293,6 +298,7 @@ function handleError (_error, errorFn) {
   errorFn(_error.message, {
     code: _error.code,
     exit: exitCode,
+    ref: reference,
   })
 }
 

--- a/test/base-command.test.js
+++ b/test/base-command.test.js
@@ -49,7 +49,29 @@ test('catch -- sdk (no action running)', async () => {
   err.code = 'ABC'
 
   await fixture.catch(err)
-  await expect(error).toHaveBeenCalledWith('msg', { exit: 30, code: 'ABC' })
+  await expect(error).toHaveBeenCalledWith('msg', expect.objectContaining({
+    exit: 30,
+    code: 'ABC',
+    ref: expect.stringMatching(/^Timestamp/),
+  }))
+  await expect(cli.action.stop).not.toHaveBeenCalled()
+})
+
+test('catch -- sdk with requestId (no action running)', async () => {
+  const err = new Error('msg')
+  err.name = 'CloudManagerError'
+  err.code = 'ABC'
+  err.sdkDetails = {
+    requestId: 'abc',
+  }
+
+  await fixture.catch(err)
+  await expect(error).toHaveBeenCalledWith('msg', expect.objectContaining({
+    exit: 30,
+    code: 'ABC',
+    ref: expect.stringMatching(/^Request Id: abc. Timestamp/),
+
+  }))
   await expect(cli.action.stop).not.toHaveBeenCalled()
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When available, the request Id is output as part of an error message like this:

```
 ›   Error: [CloudManagerSDK:ERROR_GET_EXECUTION] Cannot get execution: https://cloudmanager.adobe.io/api/program/X/pipeline/Y/execution (404 Not Found) - Pipeline Execution not 
 ›   found(s): No execution in progress: programId=X, pipelineId=Y
 ›   Code: ERROR_GET_EXECUTION
 ›   Reference: Request Id: zSO5spX7STUL5iB19b8o4UPxfiGy4sne. Timestamp: 2021-10-25T13:04:57.403Z
```

## Related Issue

#544 

## Motivation and Context

Improved error reporting

## How Has This Been Tested?

* Manual testing
* Unit testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
