### PR TITLE
fix(commerce): args fixes #552

### DIFF
--- a/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
@@ -21,13 +21,12 @@ class CacheCleanCommand extends BaseCommerceCliCommand {
     const { flags, argv } = this.parse(CacheCleanCommand)
 
     const programId = getProgramId(flags)
-    const cacheTypes = argv.slice(1)
 
     const result = await this.runSync(programId, flags.environmentId,
       {
         type: 'bin/magento',
         command: 'cache:clean',
-        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags, CacheCleanCommand)],
+        options: ['-n', ...argv, ...getFormattedFlags(flags, CacheCleanCommand)],
       },
       1000, 'cache:clean')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
@@ -21,13 +21,12 @@ class CacheFlushCommand extends BaseCommerceCliCommand {
     const { flags, argv } = this.parse(CacheFlushCommand)
 
     const programId = getProgramId(flags)
-    const cacheTypes = argv.slice(1)
 
     const result = await this.runSync(programId, flags.environmentId,
       {
         type: 'bin/magento',
         command: 'cache:flush',
-        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags, CacheFlushCommand)],
+        options: ['-n', ...argv, ...getFormattedFlags(flags, CacheFlushCommand)],
       },
       1000, 'cache:flush')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
@@ -21,13 +21,12 @@ class IndexerReindexCommand extends BaseCommerceCliCommand {
     const { flags, argv } = this.parse(IndexerReindexCommand)
 
     const programId = getProgramId(flags)
-    const indexTypes = argv.slice(1)
 
     const result = await this.runSync(programId, flags.environmentId,
       {
         type: 'bin/magento',
         command: 'indexer:reindex',
-        options: ['-n', ...indexTypes, ...getFormattedFlags(flags, IndexerReindexCommand)],
+        options: ['-n', ...argv, ...getFormattedFlags(flags, IndexerReindexCommand)],
       },
       1000, 'indexer:reindex')
 

--- a/test/commands/commerce/bin-magento/cache/clean.test.js
+++ b/test/commands/commerce/bin-magento/cache/clean.test.js
@@ -38,7 +38,7 @@ test('cache:clean - missing arg', async () => {
   await expect(runResult).rejects.toThrow(/^Missing required flag/)
 })
 
-test('maintenance:status - missing config', async () => {
+test('cache:clean - missing config', async () => {
   expect.assertions(2)
 
   const runResult = run(['--programId', '5', '--environmentId', '10'])
@@ -46,7 +46,7 @@ test('maintenance:status - missing config', async () => {
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
-test('maintenance:status', async () => {
+test('cache:clean', async () => {
   let counter = 0
   setCurrentOrgId('good')
   mockSdk.postCommerceCommandExecution = jest.fn(() =>
@@ -75,7 +75,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(11)
 
-  const runResult = run(['--programId', '5', '--environmentId', '10', '-V', '--ansi'])
+  const runResult = run(['--programId', '5', '--environmentId', '10', '-V', '--ansi', 'cacheType1', 'cacheType2'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -89,7 +89,7 @@ test('maintenance:status', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'cache:clean',
-    options: ['-n', '--version', '--ansi'],
+    options: ['-n', 'cacheType1', 'cacheType2', '--version', '--ansi'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/cache/flush.test.js
+++ b/test/commands/commerce/bin-magento/cache/flush.test.js
@@ -38,7 +38,7 @@ test('cache:flush - missing environemtId', async () => {
   await expect(runResult).rejects.toThrow(/^Missing required flag/)
 })
 
-test('maintenance:status - missing config', async () => {
+test('cache:flush - missing config', async () => {
   expect.assertions(2)
 
   const runResult = run(['--programId', '5', '--environmentId', '10'])
@@ -46,7 +46,7 @@ test('maintenance:status - missing config', async () => {
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
-test('maintenance:status', async () => {
+test('cache:flush', async () => {
   let counter = 0
   setCurrentOrgId('good')
   mockSdk.postCommerceCommandExecution = jest.fn(() =>
@@ -75,7 +75,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(11)
 
-  const runResult = run(['--programId', '5', '--environmentId', '10', '--no-ansi'])
+  const runResult = run(['--programId', '5', '--environmentId', '10', '--no-ansi', 'cacheType1', 'cacheType2'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -89,7 +89,7 @@ test('maintenance:status', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'cache:flush',
-    options: ['-n', '--no-ansi'],
+    options: ['-n', 'cacheType1', 'cacheType2', '--no-ansi'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)

--- a/test/commands/commerce/bin-magento/indexer/reindex.test.js
+++ b/test/commands/commerce/bin-magento/indexer/reindex.test.js
@@ -38,7 +38,7 @@ test('indexer:reindex - missing arg', async () => {
   await expect(runResult).rejects.toThrow(/^Missing required flag/)
 })
 
-test('maintenance:status - missing config', async () => {
+test('indexer:reindex - missing config', async () => {
   expect.assertions(2)
 
   const runResult = run(['--programId', '5', '--environmentId', '10'])
@@ -46,7 +46,7 @@ test('maintenance:status - missing config', async () => {
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:NO_IMS_CONTEXT] Unable to find IMS context aio-cli-plugin-cloudmanager.')
 })
 
-test('maintenance:status', async () => {
+test('indexer:reindex', async () => {
   let counter = 0
   setCurrentOrgId('good')
   mockSdk.postCommerceCommandExecution = jest.fn(() =>
@@ -75,7 +75,7 @@ test('maintenance:status', async () => {
 
   expect.assertions(11)
 
-  const runResult = run(['--programId', '5', '--environmentId', '10'])
+  const runResult = run(['--programId', '5', '--environmentId', '10', 'index1', 'index2'])
   await expect(runResult instanceof Promise).toBeTruthy()
   await runResult
   await expect(init.mock.calls.length).toEqual(1)
@@ -89,7 +89,7 @@ test('maintenance:status', async () => {
   await expect(mockSdk.postCommerceCommandExecution).toHaveBeenCalledWith('5', '10', {
     type: 'bin/magento',
     command: 'indexer:reindex',
-    options: ['-n'],
+    options: ['-n', 'index1', 'index2'],
   })
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledWith('5', '10', '5000')
   await expect(mockSdk.getCommerceCommandExecution).toHaveBeenCalledTimes(3)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For all commerce commands that accept arguments, pass all arg array to api, instead of slicing after the first index. 
## Description

<!--- Describe your changes in detail -->
* Refactored cache:clean, cache:flush, and indexer:reindex commands
* Updated unit tests
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
call cache:clean, cache:flush, or indexer:reindex commands with arguments, you will see first arg is ignored
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
manual and unit
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
