### PR TITLE
Upgraded release node version to 16 (from 12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
     - run: npm version
     - run: npm install
     - run: npm test
+    - run: npm run e2e
+      env:
+        E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
+        E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
+        E2E_TA_EMAIL: ${{ secrets.E2E_TA_EMAIL }}
+        E2E_IMS_ORG_ID: ${{ secrets.E2E_IMS_ORG_ID }}
+        E2E_PRIVATE_KEY_B64: ${{ secrets.E2E_PRIVATE_KEY_B64 }}
     - run: npm run semantic-release-dry-run
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
       - name: Install dependencies
         run: npm install
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ jobs:
         run: npm install
       - name: Test
         run: npm test
+      - name: End to End Test
+        run: npm run e2e
+        env:
+          E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
+          E2E_CLIENT_SECRET: ${{ secrets.E2E_CLIENT_SECRET }}
+          E2E_TA_EMAIL: ${{ secrets.E2E_TA_EMAIL }}
+          E2E_IMS_ORG_ID: ${{ secrets.E2E_IMS_ORG_ID }}
+          E2E_PRIVATE_KEY_B64: ${{ secrets.E2E_PRIVATE_KEY_B64 }}
       - name: Codecov
         uses: codecov/codecov-action@v2.1.0
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The release.yml github action failed with a syntax error.

https://github.com/adobe/aio-cli-plugin-cloudmanager/runs/7695466966?check_suite_focus=true

This appear to be due to the older version (12) of node being used. Updating release node version to 16.
This also reverts the disabling of the e2e tests in the Github actions, since it just occurred to me that is why JE removed node from the ci.yml matrix.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
