### PR TITLE
feat(variables): support service-specific pipeline variables. fixes #686

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
         include:
           - os: ubuntu-latest
-            node-version: 14.x
+            node-version: 16.x
             reportCoverage: true
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# [4.2.0](https://github.com/adobe/aio-cli-plugin-cloudmanager/compare/4.1.0...4.2.0) (2024-25-03)
+
+
+### Features
+
+* **variables:** support service-specific pipeline variables [#686](https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/686) ([3c3d804](https://github.com/adobe/aio-cli-plugin-cloudmanager/commit/3c3d80404df16ad4375f079c67cfef3ea6b15fbd))
+
 # [4.1.0](https://github.com/adobe/aio-cli-plugin-cloudmanager/compare/4.0.0...4.1.0) (2023-06-14)
 
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Cloud Manager Plugin for the [Adobe I/O CLI](https://github.com/adobe/aio-cli)
 
 * [Adobe I/O CLI](https://github.com/adobe/aio-cli)
 * Node.js version compatibility:
-    * 12.x -- 12.0.0 or higher.
-    * 14.x -- 14.0.0 or higher.
-    * 16.x -- currently incompatible due to lack of support from aio-cli.
+    * 16.x -- 16.0.0 or higher.
     * Use with odd Node versions is *not* recommended.
 
 > Although not recommended for general use, it is possible to use this plugin outside of the Adobe I/O CLI. See [Standalone Use](#standalone-use) below.
@@ -1043,19 +1041,43 @@ ARGUMENTS
   PIPELINEID  the pipeline id
 
 OPTIONS
-  -d, --delete=delete              variables/secrets to delete
-  -j, --json                       output in json format
-  -p, --programId=programId        the programId. if not specified, defaults to 'cloudmanager_programid' config value
-  -s, --secret=secret              secret values in KEY VALUE format
-  -v, --variable=variable          variable values in KEY VALUE format
-  -y, --yaml                       output in yaml format
-  --imsContextName=imsContextName  the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
+  -d, --delete=delete                                variables/secrets to delete
+  -j, --json                                         output in json format
+  -p, --programId=programId                          the programId. if not specified, defaults to 'cloudmanager_programid' config value
+  -s, --secret=secret                                secret values in KEY VALUE format
+  -v, --variable=variable                            variable values in KEY VALUE format
+  -y, --yaml                                         output in yaml format
+  --imsContextName=imsContextName                    the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager
 
-  --jsonFile=jsonFile              if set, read variables from a JSON array provided as a file; variables set through
-                                   --variable or --secret flag will take precedence
+  --jsonFile=jsonFile                                if set, read variables from a JSON array provided as a file; variables set through
+                                                     --variable or --secret flag will take precedence
 
-  --jsonStdin                      if set, read variables from a JSON array provided as standard input; variables set
-                                   through --variable or --secret flag will take precedence
+  --jsonStdin                                        if set, read variables from a JSON array provided as standard input; variables set
+                                                     through --variable or --secret flag will take precedence
+
+  --buildDelete=buildDelete                          variables/secrets to delete for build service
+
+  --buildSecret=buildSecret                          secret values in KEY VALUE format for build service
+
+  --buildVariable=buildVariable                      variable values in KEY VALUE format for build service
+
+  --functionalTestDelete=functionalTestDelete        variables/secrets to delete for functionalTest service
+
+  --functionalTestSecret=functionalTestSecret        secret values in KEY VALUE format for functionalTest service
+
+  --functionalTestVariable=functionalTestVariable    variable values in KEY VALUE format for functionalTest service
+
+  --uiTestDelete=uiTestDelete                        variables/secrets to delete for uiTest service
+
+  --uiTestSecret=uiTestSecret                        secret values in KEY VALUE format for uiTest service
+
+  --uiTestVariable=uiTestVariable                    variable values in KEY VALUE format for uiTest service
+
+  --loadTestDelete=loadTestDelete                    variables/secrets to delete for loadTest service
+
+  --loadTestSecret=loadTestSecret                    secret values in KEY VALUE format for loadTest service
+
+  --loadTestVariable=loadTestVariable                variable values in KEY VALUE format for loadTest service
 
   --yamlFile=yamlFile              if set, read variables from a YAML array provided as a file; variables set through
                                    --variable or --secret flag will take precedence

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-cli-plugin-cloudmanager",
   "description": "Cloud Manager commands for the Adobe I/O CLI",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-cloudmanager/issues",
   "dependencies": {
@@ -43,7 +43,7 @@
     "execa": "5.1.1",
     "fetch-mock": "9.11.0",
     "husky": "5.2.0",
-    "jest": "27.5.1",
+    "jest": "29.7.0",
     "jest-extended": "2.0.0",
     "jest-junit": "13.0.0",
     "node-wget": "0.4.3",
@@ -53,7 +53,7 @@
     "tmp": "0.2.1"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "files": [
     "/oclif.manifest.json",
@@ -145,7 +145,7 @@
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif-dev readme && git add README.md",
-    "e2e": "jest --collectCoverage=false --testRegex './e2e/e2e.js'",
+    "e2e": "jest --collectCoverage=false --testRegex \"/e2e/*\"",
     "semantic-release": "semantic-release",
     "semantic-release-dry-run": "semantic-release --dry-run",
     "postinstall": "husky install",

--- a/src/commands/cloudmanager/environment/bind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/bind-ip-allowlist.js
@@ -38,7 +38,7 @@ BindIPAllowlist.description = 'Bind an IP Allowlist to an environment'
 BindIPAllowlist.args = [
   commonArgs.environmentId,
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
-  commonArgs.service,
+  commonArgs.environmentServices,
 ]
 
 BindIPAllowlist.flags = {

--- a/src/commands/cloudmanager/environment/set-variables.js
+++ b/src/commands/cloudmanager/environment/set-variables.js
@@ -15,10 +15,9 @@ const BaseVariablesCommand = require('../../../base-variables-command')
 const { initSdk, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
 const { flags } = require('@oclif/command')
 const Config = require('@adobe/aio-lib-core-config')
-const _ = require('lodash')
 const commonFlags = require('../../../common-flags')
 const commonArgs = require('../../../common-args')
-const { services } = require('../../../constants')
+const { environmentServices } = require('../../../constants')
 const { codes: validationCodes } = require('../../../ValidationErrors')
 
 const IGNORED_PREFIXES = [
@@ -29,20 +28,7 @@ const IGNORED_PREFIXES = [
 
 class SetEnvironmentVariablesCommand extends BaseEnvironmentVariablesCommand {
   getFlagDefs () {
-    const coreFlagDefs = super.getFlagDefs()
-    const result = {
-      ...coreFlagDefs,
-    }
-    services.forEach(service => {
-      Object.keys(coreFlagDefs).forEach(coreFlagKey => {
-        const flagName = _.camelCase(`${service} ${coreFlagKey}`)
-        result[flagName] = {
-          ...coreFlagDefs[coreFlagKey],
-          service,
-        }
-      })
-    })
-    return result
+    return super.getFlagDefs(environmentServices)
   }
 
   async run () {
@@ -83,20 +69,9 @@ SetEnvironmentVariablesCommand.args = [
 SetEnvironmentVariablesCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
-  ...BaseVariablesCommand.setterFlags,
+  ...BaseVariablesCommand.setterFlags(environmentServices),
   strict: flags.boolean({ description: 'performs strict validation of internal variables. Can also be enabled by setting configuration property cloudmanager.environmentVariables.strictValidation to a truthy value.' }),
 }
-
-services.forEach(service => {
-  Object.keys(BaseVariablesCommand.coreSetterFlags).forEach(coreFlagKey => {
-    const coreFlag = BaseVariablesCommand.coreSetterFlags[coreFlagKey]
-    const flagName = _.camelCase(`${service} ${coreFlagKey}`)
-    SetEnvironmentVariablesCommand.flags[flagName] = flags.string({
-      description: `${coreFlag.description} for ${service} service`,
-      multiple: true,
-    })
-  })
-})
 
 SetEnvironmentVariablesCommand.aliases = [
   'cloudmanager:set-environment-variables',

--- a/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
+++ b/src/commands/cloudmanager/environment/unbind-ip-allowlist.js
@@ -40,7 +40,7 @@ UnbindIPAllowlist.strict = false
 UnbindIPAllowlist.args = [
   commonArgs.environmentId,
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
-  commonArgs.service,
+  commonArgs.environmentServices,
 ]
 
 UnbindIPAllowlist.flags = {

--- a/src/commands/cloudmanager/ip-allowlist/bind.js
+++ b/src/commands/cloudmanager/ip-allowlist/bind.js
@@ -44,7 +44,7 @@ BindIPAllowlist.strict = false
 BindIPAllowlist.args = [
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
   commonArgs.environmentId,
-  commonArgs.service,
+  commonArgs.environmentServices,
 ]
 
 BindIPAllowlist.flags = {

--- a/src/commands/cloudmanager/ip-allowlist/unbind.js
+++ b/src/commands/cloudmanager/ip-allowlist/unbind.js
@@ -44,7 +44,7 @@ UnbindIPAllowlist.strict = false
 UnbindIPAllowlist.args = [
   { name: 'ipAllowlistId', required: true, description: 'the IP allowlist id' },
   commonArgs.environmentId,
-  commonArgs.service,
+  commonArgs.environmentServices,
 ]
 
 UnbindIPAllowlist.flags = {

--- a/src/commands/cloudmanager/pipeline/set-variables.js
+++ b/src/commands/cloudmanager/pipeline/set-variables.js
@@ -14,8 +14,13 @@ const BasePipelineVariablesCommand = require('../../../base-pipeline-variables-c
 const BaseVariablesCommand = require('../../../base-variables-command')
 const { initSdk } = require('../../../cloudmanager-helpers')
 const commonFlags = require('../../../common-flags')
+const { pipelineServices } = require('../../../constants')
 
 class SetPipelineVariablesCommand extends BasePipelineVariablesCommand {
+  getFlagDefs () {
+    return super.getFlagDefs(pipelineServices)
+  }
+
   async run () {
     const { args, flags } = this.parse(SetPipelineVariablesCommand)
 
@@ -37,7 +42,7 @@ SetPipelineVariablesCommand.args = [
 SetPipelineVariablesCommand.flags = {
   ...commonFlags.global,
   ...commonFlags.programId,
-  ...BaseVariablesCommand.setterFlags,
+  ...BaseVariablesCommand.setterFlags(pipelineServices),
 }
 
 SetPipelineVariablesCommand.aliases = [

--- a/src/common-args.js
+++ b/src/common-args.js
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { services } = require('./constants')
+const { environmentServices } = require('./constants')
 
 module.exports = {
-  service: { name: 'service', required: true, options: services, description: 'the service name' },
+  environmentServices: { name: 'service', required: true, options: environmentServices, description: 'the service name' },
   environmentId: { name: 'environmentId', required: true, description: 'the environment id' },
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,8 @@ governing permissions and limitations under the License.
 */
 
 module.exports = {
-  services: ['author', 'publish', 'preview'],
+  environmentServices: ['author', 'publish', 'preview'],
+  pipelineServices: ['build', 'functionalTest', 'uiTest', 'loadTest'],
   defaultImsContextName: 'aio-cli-plugin-cloudmanager',
   exitCodes: {
     GENERAL: 1,

--- a/test/__mocks__/@adobe/aio-lib-cloudmanager.js
+++ b/test/__mocks__/@adobe/aio-lib-cloudmanager.js
@@ -105,6 +105,16 @@ function createDefaultMock () {
     }, {
       name: 'I_AM_A_SECRET',
       type: 'secretString',
+    }, {
+      name: 'FUNCTIONAL_VARIABLE',
+      value: 'something',
+      service: 'functionalTest',
+      type: 'string',
+    }, {
+      name: 'BUILD_SECRET',
+      value: 'something',
+      service: 'build',
+      type: 'secretString',
     }])),
     setPipelineVariables: jest.fn(() => Promise.resolve()),
     deleteProgram: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Description

Supports service for pipeline variables was added in the CLI.

## Related Issue

#686

## Motivation and Context

The pipeline variable API now supports service for pipeline variables and that should be available in the CLI.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
