### PR TITLE
fix(download-logs): retry download logs fixes #711

### DIFF
--- a/src/commands/cloudmanager/environment/download-logs.js
+++ b/src/commands/cloudmanager/environment/download-logs.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const { flags } = require('@oclif/command')
-const { initSdk, getProgramId, sanitizeEnvironmentId } = require('../../../cloudmanager-helpers')
+const { initSdk, getProgramId, sanitizeEnvironmentId, executeWithRetry } = require('../../../cloudmanager-helpers')
 const { cli } = require('cli-ux')
 const path = require('path')
 const commonFlags = require('../../../common-flags')
@@ -50,8 +50,10 @@ class DownloadLogs extends BaseCommand {
   }
 
   async downloadLogs (programId, environmentId, service, logName, days, outputDirectory, imsContextName = null) {
-    const sdk = await initSdk(imsContextName)
-    return sdk.downloadLogs(programId, environmentId, service, logName, days, outputDirectory)
+    return executeWithRetry(async () => {
+      const sdk = await initSdk(imsContextName)
+      return sdk.downloadLogs(programId, environmentId, service, logName, days, outputDirectory)
+    })
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add retry mechanism in case connection reset

## Related Issue

[711](https://github.com/adobe/aio-cli-plugin-cloudmanager/issues/711)

## Motivation and Context

download log operation should run with no interruption

## How Has This Been Tested?

Unit tests, regression tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
