### PR TITLE
[CMGR-76557] fix: reconnect tail-log stream after EOF or transient error

### DIFF
--- a/src/commands/cloudmanager/environment/tail-log.js
+++ b/src/commands/cloudmanager/environment/tail-log.js
@@ -31,10 +31,17 @@ class TailLog extends BaseCommand {
   }
 
   async tailLog (programId, environmentId, service, logName, imsContextName = null) {
-    return executeWithRetries(async () => {
-      const sdk = await initSdk(imsContextName)
-      return sdk.tailLog(programId, environmentId, service, logName, process.stdout)
-    })
+    while (true) {
+      try {
+        await executeWithRetries(async () => {
+          const sdk = await initSdk(imsContextName)
+          return sdk.tailLog(programId, environmentId, service, logName, process.stdout)
+        })
+      } catch (error) {
+        if (error.code) throw error
+      }
+      await new Promise(resolve => setTimeout(resolve, 2000))
+    }
   }
 }
 

--- a/test/commands/environment/tail-log.test.js
+++ b/test/commands/environment/tail-log.test.js
@@ -37,11 +37,22 @@ test('tail-log - missing config', async () => {
 test('tail-log - config', async () => {
   setCurrentOrgId('good')
 
+  // Block on the second tailLog call so the reconnect loop doesn't run indefinitely.
+  // The 2000ms reconnect delay means the second call won't happen within our 50ms window.
+  let callCount = 0
+  mockSdk.tailLog.mockImplementation(() => {
+    callCount++
+    return callCount === 1 ? Promise.resolve() : new Promise(() => {})
+  })
+
   expect.assertions(5)
 
   const runResult = TailLog.run(['17', 'author', 'aemerror', '--programId', '5'])
   await expect(runResult instanceof Promise).toBeTruthy()
-  await runResult
+  // Don't await runResult — the reconnect loop never terminates.
+  // Wait 50ms for the first sdk.tailLog() call to complete (the reconnect delay is 2000ms,
+  // so the second call hasn't been made yet).
+  await new Promise(resolve => setTimeout(resolve, 50))
   await expect(init.mock.calls.length).toEqual(1)
   await expect(init).toHaveBeenCalledWith('good', 'test-client-id', 'fake-token', 'https://cloudmanager.adobe.io')
   await expect(mockSdk.tailLog.mock.calls.length).toEqual(1)
@@ -58,3 +69,54 @@ test('tail-log - should retry 5 times and throw error', async () => {
   await expect(runResult).rejects.toThrow('[CloudManagerCLI:MAX_RETRY_REACHED] Max retries reached')
   await expect(mockSdk.tailLog.mock.calls.length).toEqual(5)
 })
+
+test('tail-log - reconnects after normal stream end', async () => {
+  setCurrentOrgId('good')
+  mockSdk.tailLog.mockClear()
+
+  let callCount = 0
+  mockSdk.tailLog.mockImplementation(() => {
+    callCount++
+    // First two calls resolve immediately (simulating EOF / end of stream)
+    // Third call blocks forever (simulating an active stream)
+    return callCount < 3 ? Promise.resolve() : new Promise(() => {})
+  })
+
+  TailLog.run(['17', 'author', 'aemerror', '--programId', '5'])
+
+  // Wait long enough for the 2000ms reconnect delay to fire at least once
+  await new Promise(resolve => setTimeout(resolve, 2500))
+
+  expect(mockSdk.tailLog.mock.calls.length).toBeGreaterThanOrEqual(2)
+}, 10000)
+
+test('tail-log - retries silently on transient non-auth error', async () => {
+  setCurrentOrgId('good')
+  mockSdk.tailLog.mockClear()
+
+  let callCount = 0
+  mockSdk.tailLog.mockImplementation(() => {
+    callCount++
+    if (callCount === 1) {
+      // Simulate a 404 (log stream not ready yet — as seen during the midnight rotation window)
+      return Promise.reject(Object.assign(new Error('Not Found'), {
+        sdkDetails: { response: { status: 404 } },
+      }))
+    }
+    // Second call blocks (active stream established)
+    return new Promise(() => {})
+  })
+
+  const runResult = TailLog.run(['17', 'author', 'aemerror', '--programId', '5'])
+
+  // Wait for the 2000ms reconnect delay to fire after the first rejected call
+  await new Promise(resolve => setTimeout(resolve, 2500))
+
+  // The CLI must have retried (2nd call made)
+  expect(mockSdk.tailLog.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+  // The CLI must NOT have rejected (no crash on transient error)
+  await expect(
+    Promise.race([runResult.then(() => 'resolved'), Promise.resolve('still-running')]),
+  ).resolves.toBe('still-running')
+}, 10000)


### PR DESCRIPTION
## Summary

- Adds a resilient `while(true)` reconnect loop in `TailLog.tailLog()` so the CLI never exits when the log stream ends
- Swallows transient errors (no `error.code`: 404, network drops, Azure SAS URL expiry) and retries after a 2-second delay
- Re-throws fatal CLI-coded errors (`error.code` set: `MAX_RETRY_REACHED`, `NO_IMS_CONTEXT`) so auth and config failures still surface correctly
- Ctrl+C still exits immediately (SIGINT kills the process regardless of the loop)

**Jira:** https://jira.corp.adobe.com/browse/CMGR-76557
**Root cause:** `executeWithRetries` only retried on HTTP 401/403. EOF at midnight log rotation resolved normally — no error, no retry, silent CLI exit.

## Test plan

- [ ] New test: `tail-log - reconnects after normal stream end` — verifies `sdk.tailLog` called ≥2 times after EOF
- [ ] New test: `tail-log - retries silently on transient non-auth error` — verifies 404 is swallowed and CLI stays alive
- [ ] Updated test: `tail-log - config` — updated to not await `runResult` (loop never terminates); all 5 assertions still pass
- [ ] Existing test: `tail-log - should retry 5 times and throw error` — unchanged, `MAX_RETRY_REACHED` (has `error.code`) still re-thrown correctly
- [ ] Manual: run `aio cloudmanager:tail-log` before midnight UTC and confirm stream continues through rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)